### PR TITLE
adding more child docs to book

### DIFF
--- a/.github/workflows/starting-course.yml
+++ b/.github/workflows/starting-course.yml
@@ -37,6 +37,8 @@ jobs:
             .github/switch_sync_repo.yml \
             child/* \
             04-workspace_modules.Rmd \
+            05-billing_modules.Rmd \
+            06-onboarding_modules.Rmd \
             resources/code_output \
             resources/screenshots \
             resources/course_screenshots \

--- a/02-chapter_of_course.Rmd
+++ b/02-chapter_of_course.Rmd
@@ -28,9 +28,6 @@ For this chapter, we'll need the following packages attached:
 library(magrittr)
 ```
 
-# Topic of Section
-
-You can write all your text in sections like this!
 
 ## Subtopic
 

--- a/05-billing_modules.Rmd
+++ b/05-billing_modules.Rmd
@@ -1,6 +1,4 @@
-# (PART\*) AnVIL Modules {-}
-
-# Workspaces
+# Billing
 
 Modules about billing and Billing Projects on Google Cloud Platform and Terra.
 

--- a/05-billing_modules.Rmd
+++ b/05-billing_modules.Rmd
@@ -1,0 +1,62 @@
+# (PART\*) AnVIL Modules {-}
+
+# Workspaces
+
+Modules about billing and Billing Projects on Google Cloud Platform and Terra.
+
+<br>
+
+## Create Google Billing Account
+
+```{r, echo = FALSE, results='asis'}
+cow::borrow_chapter(
+  doc_path = "child/_child_google_billing_create_account.Rmd",
+  repo_name = "jhudsl/AnVIL_Template"
+)
+```
+
+## Add Terra to Google Billing Account
+
+```{r, echo = FALSE, results='asis'}
+cow::borrow_chapter(
+  doc_path = "child/_child_google_billing_add_terra.Rmd",
+  repo_name = "jhudsl/AnVIL_Template"
+)
+```
+
+## Create Terra Billing Project
+
+```{r, echo = FALSE, results='asis'}
+cow::borrow_chapter(
+  doc_path = "child/_child_terra_create_billing_project.Rmd",
+  repo_name = "jhudsl/AnVIL_Template"
+)
+```
+
+## Add Members to Google Billing Account
+
+```{r, echo = FALSE, results='asis'}
+cow::borrow_chapter(
+  doc_path = "child/_child_google_billing_create_account.Rmd",
+  repo_name = "jhudsl/AnVIL_Template"
+)
+```
+
+## Set Alerts for Google Billing
+
+```{r, echo = FALSE, results='asis'}
+cow::borrow_chapter(
+  doc_path = "child/_child_google_billing_set_alerts.Rmd",
+  repo_name = "jhudsl/AnVIL_Template"
+)
+```
+
+## View Spend for Google Billing
+
+```{r, echo = FALSE, results='asis'}
+cow::borrow_chapter(
+  doc_path = "child/_child_google_billing_view_spend.Rmd",
+  repo_name = "jhudsl/AnVIL_Template"
+)
+```
+

--- a/05-billing_modules.Rmd
+++ b/05-billing_modules.Rmd
@@ -35,7 +35,7 @@ cow::borrow_chapter(
 
 ```{r, echo = FALSE, results='asis'}
 cow::borrow_chapter(
-  doc_path = "child/_child_google_billing_create_account.Rmd",
+  doc_path = "child/_child_google_billing_add_member.Rmd",
   repo_name = "jhudsl/AnVIL_Template"
 )
 ```

--- a/06-misc_modules.Rmd
+++ b/06-misc_modules.Rmd
@@ -1,0 +1,17 @@
+# (PART\*) AnVIL Modules {-}
+
+# Workspaces
+
+Miscellaneous additional modules
+
+<br>
+
+## Create Google Account
+
+```{r, echo = FALSE, results='asis'}
+cow::borrow_chapter(
+  doc_path = "child/_child_google_create_account.Rmd",
+  repo_name = "jhudsl/AnVIL_Template"
+)
+```
+

--- a/06-misc_modules.Rmd
+++ b/06-misc_modules.Rmd
@@ -1,6 +1,4 @@
-# (PART\*) AnVIL Modules {-}
-
-# Workspaces
+# Miscellaneous
 
 Miscellaneous additional modules
 

--- a/06-onboarding_modules.Rmd
+++ b/06-onboarding_modules.Rmd
@@ -1,6 +1,6 @@
-# Miscellaneous
+# Onboarding
 
-Miscellaneous additional modules
+Joining a team on AnVIL.
 
 <br>
 

--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -7,7 +7,7 @@ rmd_files: ["index.Rmd",
             "03-AnVIL_modules.Rmd",
             "04-workspace_modules.Rmd",
             "05-billing_modules.Rmd",
-            "06-misc_modules.Rmd",
+            "06-onboarding_modules.Rmd",
             "About.Rmd",
             "References.Rmd"]
 new_session: yes

--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -6,6 +6,8 @@ rmd_files: ["index.Rmd",
             "02-chapter_of_course.Rmd",
             "03-AnVIL_modules.Rmd",
             "04-workspace_modules.Rmd",
+            "05-billing_modules.Rmd",
+            "06-misc_modules.Rmd"
             "About.Rmd",
             "References.Rmd"]
 new_session: yes

--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -7,7 +7,7 @@ rmd_files: ["index.Rmd",
             "03-AnVIL_modules.Rmd",
             "04-workspace_modules.Rmd",
             "05-billing_modules.Rmd",
-            "06-misc_modules.Rmd"
+            "06-misc_modules.Rmd",
             "About.Rmd",
             "References.Rmd"]
 new_session: yes

--- a/resources/dictionary.txt
+++ b/resources/dictionary.txt
@@ -5,6 +5,7 @@ Datatrail
 DataTrail
 dropdown
 GDSCN
+Gmail
 impactful
 ITCR
 itcrtraining


### PR DESCRIPTION
added the rest of the child docs from Getting Started to the collection of modules listed in the AnVIL_Template book

(also deleted a line from the `02-chapter-of-course.Rmd` that was making it show up as two separate chapters, which was weird and confusing)

I put all the billing stuff into one "chapter" for now, but I imaging "Billing" might get broken up if we add more modules (e.g. on creating and managing groups), to keep things easily findable.

As far as organization - It'll be a huge pain to rename or reorganize the child documents themselves once other books start pointing to them, since it'll break the import links.  But, it's no problem at all to reorganize how they're presented in the AnVIL_Template "book".  So I'm thinking we keep the `/child` directory flat, and use the AnVIL_Template book to keep things organized.
