### PR TITLE
Fix online -> open-source in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## AnVIL Template
 
-Based on [_Online Tools for Training Resources (OTTR)_](https://github.com/jhudsl/OTTR_Template)
+Based on [_Open-source Tools for Training Resources (OTTR)_](https://github.com/jhudsl/OTTR_Template)
 
 The purpose of this template and is to make publishing maintenance for AnVIL content across multiple different platforms _less painful_.
 


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?
This is a leftover from in some places we accidentally put that OTTR stands for "Online" instead of "Open-source" so I'm trying to fix that here since I noticed it. 
