### PR TITLE
Ava/test custom workflow

### DIFF
--- a/.github/workflows/custom-workflow.yml
+++ b/.github/workflows/custom-workflow.yml
@@ -56,6 +56,7 @@ jobs:
           GH_PAT: ${{ secrets.gh_pat }}
         run: |
           sudo apt-get install libcurl4-openssl-dev
+          rm resources/AnVIL_repos.tsv
 
           # Run repo check script
           Rscript --vanilla "scripts/anvil_repo_check.R" --git_pat "$GH_PAT"

--- a/.github/workflows/custom-workflow.yml
+++ b/.github/workflows/custom-workflow.yml
@@ -56,7 +56,9 @@ jobs:
           GH_PAT: ${{ secrets.gh_pat }}
         run: |
           sudo apt-get install libcurl4-openssl-dev
+          # Need a clean render of the AnVIL repos library
           rm resources/AnVIL_repos.tsv
+          rm docs/index.html
 
           # Run repo check script
           Rscript --vanilla "scripts/anvil_repo_check.R" --git_pat "$GH_PAT"

--- a/.github/workflows/custom-workflow.yml
+++ b/.github/workflows/custom-workflow.yml
@@ -1,5 +1,5 @@
 
-name: Custom Workflow
+name: AnVIL Library Build
 
 on:
   workflow_call:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -58,7 +58,7 @@ jobs:
       dockerfiles_changed: steps.verify-changed-files.outputs.files_changed
 
   call-custom-workflow:
-    name: Custom Workflow
+    name: AnVIL Library Build
     needs: yaml-check
     uses: ./.github/workflows/custom-workflow.yml
     with:
@@ -411,7 +411,9 @@ jobs:
       # Run bookdown rendering
       - name: Run bookdown render
         id: bookdown
-        run: Rscript -e "bookdown::render_book('index.Rmd', output_format = 'all')"
+        run: |
+          rm docs/index.html
+          Rscript -e "bookdown::render_book('index.Rmd', output_format = 'all')"
 
       # Run TOC-less version
       # Rendered content for Leanpub and Coursera is very similar.

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -411,9 +411,7 @@ jobs:
       # Run bookdown rendering
       - name: Run bookdown render
         id: bookdown
-        run: |
-          rm docs/index.html
-          Rscript -e "bookdown::render_book('index.Rmd', output_format = 'all')"
+        run: Rscript -e "bookdown::render_book('index.Rmd', output_format = 'all')"
 
       # Run TOC-less version
       # Rendered content for Leanpub and Coursera is very similar.

--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -33,7 +33,7 @@ jobs:
       toggle_quiz_check: "${{ env.CHECK_QUIZZES }}"
 
   call-custom-workflow:
-    name: Custom Workflow
+    name: AnVIL Library Build
     needs: yaml-check
     uses: ./.github/workflows/custom-workflow.yml
     with:

--- a/index.Rmd
+++ b/index.Rmd
@@ -19,6 +19,8 @@ This book is part of a series of books for the Genomic Data Science Analysis, Vi
 
 Please check out our full collection of AnVIL and related resources below!
 
+some change
+
 ```{r, echo = FALSE, message = FALSE, warning = FALSE}
 source("scripts/anvil_repo_table.R")
 

--- a/index.Rmd
+++ b/index.Rmd
@@ -33,3 +33,5 @@ exclude = c(
 # Create table for AnVIL repos detected through the API
 knitr::kable(make_anvil_repo_table(exclude), format = "html")
 ```
+
+Insignificant change

--- a/index.Rmd
+++ b/index.Rmd
@@ -19,8 +19,6 @@ This book is part of a series of books for the Genomic Data Science Analysis, Vi
 
 Please check out our full collection of AnVIL and related resources below!
 
-some change
-
 ```{r, echo = FALSE, message = FALSE, warning = FALSE}
 source("scripts/anvil_repo_table.R")
 

--- a/index.Rmd
+++ b/index.Rmd
@@ -33,5 +33,3 @@ exclude = c(
 # Create table for AnVIL repos detected through the API
 knitr::kable(make_anvil_repo_table(exclude), format = "html")
 ```
-
-Insignificant change

--- a/resources/AnVIL_repos.tsv
+++ b/resources/AnVIL_repos.tsv
@@ -1,13 +1,3 @@
-name	html_url
-AnVIL_Book_Getting_Started	https://github.com/jhudsl/AnVIL_Book_Getting_Started
-GDSCN_Book_SARS_Galaxy_on_AnVIL	https://github.com/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL
-GDSCN_bookdown_style	https://github.com/jhudsl/GDSCN_bookdown_style
-GDSCN_Book_Statistics_for_Genomics_PCA	https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA
-GDSCN_Book_Statistics_for_Genomics_Differential_Expression	https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression
-GDSCN_Book_Statistics_for_Genomics_RNA-seq	https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq
-GDSCN_Book_Statistics_for_Genomics_scRNA-seq	https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq
-anvil-intro	https://github.com/jhudsl/anvil-intro
-AnVIL_Book_WDL	https://github.com/jhudsl/AnVIL_Book_WDL
-AnVIL_Template	https://github.com/jhudsl/AnVIL_Template
-AnVIL_Template_Test	https://github.com/jhudsl/AnVIL_Template_Test
-AnVIL_Book_Instructor_Guide	https://github.com/jhudsl/AnVIL_Book_Instructor_Guide
+name	homepage	html_url	anvil	topics
+AnVIL_Template	https://jhudatascience.org/AnVIL_Template/	https://github.com/jhudsl/AnVIL_Template	TRUE	anvil, template
+AnVIL_Book_Getting_Started	https://jhudatascience.org/AnVIL_Book_Getting_Started	https://github.com/jhudsl/AnVIL_Book_Getting_Started	TRUE	anvil

--- a/scripts/anvil_repo_check.R
+++ b/scripts/anvil_repo_check.R
@@ -37,14 +37,20 @@ if (!(httr::http_error(req))) {
     jsonlite::fromJSON(httr::content(req, as = "text"), flatten = TRUE)
   repo_df <-
     dplyr::tibble(repo_dat$items) %>%
-    dplyr::select(name, homepage, html_url) %>%
+    dplyr::select(name, homepage, html_url, description) %>%
+    # Search for AnVIL in topics
     dplyr::bind_cols(tibble(anvil = unlist(
       lapply(repo_dat$items$topics, function(x) {
         "anvil" %in% x
       })
-    ))) %>% dplyr::bind_cols(tibble(topics = unlist(
+    ))) %>% 
+    # Collapse topics so they can be printed
+    dplyr::bind_cols(tibble(topics = unlist(
       lapply(repo_dat$items$topics, paste, collapse = ", ")
-    ))) %>% filter(anvil, !(is.na(homepage)))
+    ))) %>% 
+    # Filter for relevance, homepage, and description
+    dplyr::filter(anvil, !(is.na(homepage)), homepage != "", !(is.na(description))) %>% 
+    dplyr::relocate(description, .before = topics)
   
   # Create an artifact file containing the AnVIL repos, else write an empty file
   if (!dir.exists("resources")) {

--- a/scripts/anvil_repo_check.R
+++ b/scripts/anvil_repo_check.R
@@ -20,23 +20,31 @@ opt_parser <- optparse::OptionParser(option_list = option_list)
 opt <- optparse::parse_args(opt_parser)
 git_pat <- opt$git_pat
 
-message(paste("Checking for AnVIL repositories..."))
+message(paste("Checking for repositories..."))
 
 # Request search results specific to AnVIL within the jhudsl organization
 # and provide the appropriate GH token
 req <- httr::GET(
-  "https://api.github.com/search/repositories?q=GDSCN+user:jhudsl+OR+AnVIL+user:jhudsl",
+  "https://api.github.com/search/repositories?q=user:jhudsl&per_page=500",
   httr::add_headers(Authorization = paste("token", git_pat))
 )
 
 if (!(httr::http_error(req))) {
   message(paste("API request successful!"))
-  
+
   # Read in and save data
   repo_dat <-
     jsonlite::fromJSON(httr::content(req, as = "text"), flatten = TRUE)
   repo_df <-
-    dplyr::tibble(repo_dat$items) %>% dplyr::select(name, html_url)
+    dplyr::tibble(repo_dat$items) %>%
+    dplyr::select(name, homepage, html_url) %>%
+    dplyr::bind_cols(tibble(anvil = unlist(
+      lapply(repo_dat$items$topics, function(x) {
+        "anvil" %in% x
+      })
+    ))) %>% dplyr::bind_cols(tibble(topics = unlist(
+      lapply(repo_dat$items$topics, paste, collapse = ", ")
+    ))) %>% filter(anvil, !(is.na(homepage)))
   
   # Create an artifact file containing the AnVIL repos, else write an empty file
   if (!dir.exists("resources")) {

--- a/scripts/anvil_repo_table.R
+++ b/scripts/anvil_repo_table.R
@@ -19,19 +19,21 @@ make_anvil_repo_table <- function(exclude = NULL) {
   # templates, etc)
   df <-
     df %>%
-    filter(!(name %in% exclude)) %>%
-    rename(`Book Name` = name,
-           `Link` = html_url,
-           Topics = topics) %>%
-    arrange(`Book Name`) %>% 
-    mutate( `Link` = paste0(homepage, " ([github](", Link, "))")) %>% 
-    select(!c(homepage, anvil))
+    filter(!(name %in% exclude)) 
   
   # Do some cleaning of strings
-  df$`Book Name` <-
-    df$`Book Name` %>%
+  df$name <-
+    df$name %>%
     stringr::str_replace_all("_Book_", ": ") %>%
     stringr::str_replace_all("_", " ")
+  
+  # Concatenate columns to create links
+  df <-
+    df %>% 
+    mutate(`Book Name` = paste0("[", name, "](", homepage, ") ([github](", html_url, "))")) %>% 
+    arrange(`Book Name`) %>%
+    rename(Description = description, Topics = topics) %>% 
+    select(`Book Name`, Description, Topics)
   
   return(df)
 }

--- a/scripts/anvil_repo_table.R
+++ b/scripts/anvil_repo_table.R
@@ -21,20 +21,17 @@ make_anvil_repo_table <- function(exclude = NULL) {
     df %>%
     filter(!(name %in% exclude)) %>%
     rename(`Book Name` = name,
-           `Link` = html_url) %>%
-    arrange(`Book Name`)
+           `Link` = html_url,
+           Topics = topics) %>%
+    arrange(`Book Name`) %>% 
+    mutate( `Link` = paste0(homepage, " ([github](", Link, "))")) %>% 
+    select(!c(homepage, anvil))
   
   # Do some cleaning of strings
   df$`Book Name` <-
     df$`Book Name` %>%
     stringr::str_replace_all("_Book_", ": ") %>%
     stringr::str_replace_all("_", " ")
-  
-  # Replace github url with DaSL url
-  df$Link <-
-    stringr::str_replace_all(df$Link,
-                             "https://github.com/jhudsl",
-                             "https://jhudatascience.org")
   
   return(df)
 }


### PR DESCRIPTION
Making some changes to the way the library autogenerates:
- query now looks at all jhu repos with added page limit of 500.
- pulls out the homepage
- checks for `anvil` within topics tagged in the repo description, and removes any that don't have it
- pastes topics for easy viewing in a rendered table
- removes any repos without a homepage
- includes a github link when the table is rendered