### PR TITLE
Add auto issue for AnVIL Collection

### DIFF
--- a/.github/automatic-issues/add-repo-to-anvil-collection.md
+++ b/.github/automatic-issues/add-repo-to-anvil-collection.md
@@ -1,0 +1,9 @@
+
+If you want this repository to be added to the AnVIL Collection, make sure you do the following:
+
+- Click the gear icon on the top right of the "Code" page next to "About"
+- [ ] Create a repository description
+- [ ] Add the homepage where your course will be rendered
+- [ ] Add the topic tag `anvil`. You should also supply any other relevant tags.
+
+For more information on these settings see instructions in the [wiki pages](https://github.com/jhudsl/AnVIL_Template/wiki/The-AnVIL-Collection#adding-your-course-to-the-anvil-collection).

--- a/.github/workflows/starting-course.yml
+++ b/.github/workflows/starting-course.yml
@@ -134,3 +134,12 @@ jobs:
           title: Reminder - Add to jhudsl library
           content-filepath: .github/automatic-issues/add-to-library.md
           labels: automated training issue
+
+      # Issue for reminding people to tag their repo to ensure it gets added to the ANIVL Collection
+      - name: New Course - Add Repo to AnVIL Collection
+        uses: peter-evans/create-issue-from-file@v2.3.2
+        with:
+          title: New Course - Add Repo to AnVIL Collection
+          content-filepath: .github/automatic-issues/add-repo-to-anvil-collection.md
+          labels: automated training issue
+          


### PR DESCRIPTION
This creates an automatic issue for new template users reminding them of the necessary steps to add their course to the anvil library. There are also automatic instructions in the wiki!