### PR TITLE
Alternative text for update-enrollment.md

### DIFF
--- a/.github/automatic-issues/update-enrollment.md
+++ b/.github/automatic-issues/update-enrollment.md
@@ -1,9 +1,9 @@
 
 The original template: https://github.com/jhudsl/OTTR_Template is always a work in progress.
-We are working on adding more features and smoothing out bugs as we go.
+We are working on adding more features and smoothing out bugs as we go. The AnVIL Template collects these and can pass them along to this repository.
 
-If you want to receive updates from the original template to your course template, you will need to enroll this repository to the template updates by adding it to the `sync.yml` file.
+If you want to receive updates from the AnVIL template to your course template, you will need to enroll this repository to the template updates by adding it to the `sync.yml` file.
 
-- [ ] [Follow these instructions](https://github.com/jhudsl/OTTR_Template/wiki/Start-a-new-course#10-enroll-your-repository-for-ottrpal-updates) to enroll your course repository to receive these updates.
+- [ ] [Follow these instructions](https://github.com/jhudsl/AnVIL_Template/wiki/Start-a-New-Book-or-Course#enroll-your-repository-for-anvil-updates) to enroll your course repository to receive these updates.
 
 - [ ] [Ensure that you have followed these instructions](https://github.com/jhudsl/OTTR_Template/wiki/Start-a-new-course#5-add-jhudsl-robot-as-a-collaborator) to add the `jhudsl-robot` as a collaborator to your repository.


### PR DESCRIPTION
This builds off @KatherineCox 's work but takes the following approach:
- OTTR will push updates to AnVIL_Template
- AnVIL_Template will push updates to all downstream repos.

This means we need to remove the following from OTTR_Template/.github/sync.yml:
- [ ] jhudsl/AnVIL_Book_Getting_Started
- [ ] jhudsl/AnVIL_Book_Instructor_Guide
- [ ] jhudsl/AnVIL_Book_WDL
- [ ] jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL

And add the following to AnVIL_Template/.github/sync.yml
- [ ] AnVIL_Book_WDL 
- [ ] AnVIL_Book_Getting_Started 
- [ ] phylogenetic-techniques
- [ ] GDSCN_Book_Statistics_for_Genomics_Differential_Expression 
- [ ] GDSCN_Book_SARS_Galaxy_on_AnVIL 
- [ ] GDSCN_Book_Statistics_for_Genomics_scRNA-seq
- [ ] GDSCN_Book_Statistics_for_Genomics_RNA-seq 
- [ ] GDSCN_Book_Statistics_for_Genomics_PCA
- [ ] AnVIL_Book_Instructor_Guide 
- [ ] fhdsl/AnVIL_Book_Epigenetics_Intro