### PR TITLE
Do not delete Rmds 4-6 on template cleanup

### DIFF
--- a/.github/workflows/starting-course.yml
+++ b/.github/workflows/starting-course.yml
@@ -36,9 +36,6 @@ jobs:
             .github/sync.yml \
             .github/switch_sync_repo.yml \
             child/* \
-            04-workspace_modules.Rmd \
-            05-billing_modules.Rmd \
-            06-onboarding_modules.Rmd \
             resources/code_output \
             resources/screenshots \
             resources/course_screenshots \


### PR DESCRIPTION
When this template is used, it tries to render all the files listed in _bookdown.yml. However, the starting-course workflow removes Rmds 4-6. This causes a render failure unless the user knows to delete these files from _bookdown.yml.

https://github.com/jhudsl/AnVIL_Template/blob/c21b669621482208bb50add9c36915d8ab47fbde/_bookdown.yml#L4-L12

Removing these files from the list in starting-course.yml keeps them when the newly cloned repo is cleaned up.

https://github.com/jhudsl/AnVIL_Template/blob/c21b669621482208bb50add9c36915d8ab47fbde/.github/workflows/starting-course.yml#L38-L42