### PR TITLE
Update sync.yml

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -5,7 +5,10 @@ group:
       - source: .github/workflows/
         dest: .github/workflows/
         exclude: |
+          send-updates.yml
+          test-send-updates.yml
           starting-course.yml
+          release-notes.yml
       - source: .github/ISSUE_TEMPLATE/course-problem-report.md
         dest: .github/ISSUE_TEMPLATE/course-problem-report.md
       - source: .github/ISSUE_TEMPLATE/course-content-add.md
@@ -18,6 +21,8 @@ group:
         dest: scripts/quiz-check.R
       - source: scripts/git_repo_check.R
         dest: scripts/git_repo_check.R
+      - source: scripts/make_screenshots.R
+        dest: scripts/make_screenshots.R
       - source: code_of_conduct.md
         dest: code_of_conduct.md
       - source: style-sets


### PR DESCRIPTION
- I'm not actually sure what `make_screenshots.R` does, but it's run as part of `render-all`, so, I think we need it.
- Excluded the workflows involved in sending out sync PRs, since the books don't need them