### PR TITLE
separate syncing for AnVIL _output.yml

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -34,8 +34,6 @@ group:
         deleteOrphaned: true
       - source: assets/toc_close.css
         dest: assets/toc_close.css
-      - source: _output.yml
-        dest: _output.yml
       - source: scripts/anvil_repo_check.R
         dest: scripts/anvil_repo_check.R
       - source: scripts/anvil_repo_table.R
@@ -53,3 +51,19 @@ group:
       jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA
       jhudsl/phylogenetic-techniques
 ###ADD NEW REPO HERE following the format above#
+
+# AnVIL repos should sync AnVIL version of _output.yml
+  - files:
+      - source: _output.yml
+        dest: _output.yml
+    repos: |
+      fhdsl/AnVIL_Book_Epigenetics_Intro
+      jhudsl/AnVIL_Book_Getting_Started
+      jhudsl/AnVIL_Book_Instructor_Guide
+      jhudsl/AnVIL_Book_WDL
+      jhudsl/phylogenetic-techniques
+
+# GDSCN repos should sync the GDSCN version of _output.yml, once it exists
+# In the meantime, don't clobber their existing _output.yml
+
+


### PR DESCRIPTION
`_output.yml` is where you set the css, logo, header image, etc.

I think we can get away with having this file be the only thing different between AnVIL and GDSCN repos.