### PR TITLE
update automatic issues

### DIFF
--- a/.github/automatic-issues/add-repo-to-anvil-collection.md
+++ b/.github/automatic-issues/add-repo-to-anvil-collection.md
@@ -6,4 +6,8 @@ If you want this repository to be added to the AnVIL Collection, make sure you d
 - [ ] Add the homepage where your course will be rendered
 - [ ] Add the topic tag `anvil`. You should also supply any other relevant tags.
 
+Following these steps will also automatically add this repository to the [DaSL Collection](https://hutchdatascience.org/DaSL_Collection/) if this repository is owned by one of the DaSL organizations.
+
 For more information on these settings see instructions in the [wiki pages](https://github.com/jhudsl/AnVIL_Template/wiki/The-AnVIL-Collection#adding-your-course-to-the-anvil-collection).
+
+For more information about adding repositories to the DaSL Collection, see the [DaSL Collection README](https://github.com/fhdsl/DaSL_Collection#readme).

--- a/.github/automatic-issues/add-to-library.md
+++ b/.github/automatic-issues/add-to-library.md
@@ -1,8 +1,0 @@
-
-\* This is only pertinent to courses in the `jhudsl` organization. 
-
-To help learners find your course, and for it to be tracked in the future, you may want to consider adding the course to the jhudsl course library.
-
-You should not worry about adding the course before it is ready to be made public but this issue is to remind you to do so.
-
-[Follow these instructions](https://github.com/jhudsl/OTTR_Template/wiki/Release-a-course-for-public-viewing) to add this new course to the jhudsl library.

--- a/.github/workflows/starting-course.yml
+++ b/.github/workflows/starting-course.yml
@@ -124,15 +124,6 @@ jobs:
           echo ::set-output name=org_name::$org_name
           echo $org_name
 
-      # Issue for adding the course to the jhudsl library
-      - name: Reminder - Add to jhudsl library
-        if: ${{ steps.get_org_name.outputs.org_name == 'jhudsl' }}
-        uses: peter-evans/create-issue-from-file@v4
-        with:
-          title: Reminder - Add to jhudsl library
-          content-filepath: .github/automatic-issues/add-to-library.md
-          labels: automated training issue
-
       # Issue for reminding people to tag their repo to ensure it gets added to the ANIVL Collection
       - name: New Course - Add Repo to AnVIL Collection
         uses: peter-evans/create-issue-from-file@v4
@@ -140,4 +131,4 @@ jobs:
           title: New Course - Add Repo to AnVIL Collection
           content-filepath: .github/automatic-issues/add-repo-to-anvil-collection.md
           labels: automated training issue
-          
+


### PR DESCRIPTION
Updating the automatic issues pertaining to adding a course to the DaSL collection.
- adds a bit about DaSL collection to automatic issue `add-repo-to-anvil-collection`
- deletes automatic issue `add-to-library`
- updates `starting-course.yml`