### PR TITLE
remove packages bibliography from GDSCN index.Rmd

### DIFF
--- a/style-sets/GDSCN/index.Rmd
+++ b/style-sets/GDSCN/index.Rmd
@@ -3,20 +3,12 @@ title: "GDSCN: Course Name "
 date: "`r format(Sys.time(), '%B %d, %Y')`"
 site: bookdown::bookdown_site
 documentclass: book
-bibliography: [book.bib, packages.bib]
+bibliography: book.bib
 biblio-style: apalike
 link-citations: yes
 description: "Description about Course/Book."
 favicon: assets/GDSCN_style/gdscn_favicon.ico
 ---
-
-
-```{r include=FALSE}
-# automatically create a bib database for R packages
-knitr::write_bib(c(
-  .packages(), "bookdown", "knitr", "rmarkdown"
-), "packages.bib")
-```
 
 # About this Course {-}
 


### PR DESCRIPTION
This matches GDSCN up with the main AnVIL index.Rmd, where we don't have a package bibliography.  I don't have a strong opinion on having or not having this, just going for consistency.