### PR TITLE
Change ToC to link to hutch DaSL

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -61,10 +61,7 @@ group:
         dest: _output.yml
     repos: |
       fhdsl/AnVIL_Book_Epigenetics_Intro
-      jhudsl/AnVIL_Book_Getting_Started
-      jhudsl/AnVIL_Book_Instructor_Guide
       jhudsl/AnVIL_Book_WDL
-      jhudsl/phylogenetic-techniques
 
 # GDSCN repos should sync the GDSCN version of _output.yml
 # They should also sync the top level assets into an AnVIL style-set
@@ -77,5 +74,29 @@ group:
         dest: style-sets/AnVIL/index.Rmd
     repos: |
       jhudsl/GDSCN_Template_Test
+
+# Repos where Hopkins took the lead have JHU branding instead of Hutch
+  - files:
+      - source: style-sets/AnVIL_JHU/_output.yml
+        dest: _output.yml
+      - source: _output.yml
+        dest: style-sets/AnVIL/_output.yml
+      - source: index.Rmd
+        dest: style-sets/AnVIL/index.Rmd
+    repos: |
+      jhudsl/AnVIL_Book_Getting_Started
+      jhudsl/AnVIL_Book_Instructor_Guide
+      jhudsl/AnVIL_Phylogenetic-Techniques
+
+  - files:
+      - source: style-sets/GDSCN_JHU/_output.yml
+        dest: _output.yml
+      - source: _output.yml
+        dest: style-sets/AnVIL/_output.yml
+      - source: index.Rmd
+        dest: style-sets/AnVIL/index.Rmd
+    repos: |
+      jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL
+      jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA
 
 

--- a/_output.yml
+++ b/_output.yml
@@ -11,6 +11,6 @@ bookdown::gitbook:
        <a href="https://anvilproject.org/" target="_blank"><img src="assets/AnVIL_style/logo-anvil.png" style="width: 80%; padding-left: 15px; padding-top: 8px;"</a>
       after: |
        <p style="text-align:center;"> <a href="https://github.com/jhudsl/OTTR_Template" target="blank" > This content was published with</a> <a href="https://bookdown.org/" target="blank"> bookdown by: </a> </p>
-       <p style="text-align:center;"> <a href="http://jhudatascience.org/"> The Johns Hopkins Data Science Lab </a></p>
-       <a href="http://jhudatascience.org/"><img src="https://jhudatascience.org/images/dasl.png" style=" width: 80%; padding-left: 40px; padding-top: 8px; vertical-align: top "</a>
+       <p style="text-align:center;"> <a href="http://hutchdatascience.org/"> The Fred Hutch Data Science Lab </a></p>
+       <a href="http://hutchdatascience.org/"><img src="https://hutchdatascience.org/images/FHDataScienceLab_RecDropped.png" style=" width: 80%; padding-left: 40px; padding-top: 8px; vertical-align: top "</a>
        <p style="text-align:center; font-size: 12px;"> <a href="https://github.com/rstudio4edu/rstudio4edu-book/"> Style adapted from: rstudio4edu-book </a> <a href ="https://creativecommons.org/licenses/by/2.0/"> (CC-BY 2.0) </a></p>

--- a/style-sets/AnVIL_JHU/_output.yml
+++ b/style-sets/AnVIL_JHU/_output.yml
@@ -1,0 +1,16 @@
+bookdown::gitbook:
+  css: assets/AnVIL_style/style.css
+  includes:
+    before_body: assets/AnVIL_style/big-image_anvil.html
+    after_body: assets/AnVIL_style/footer.html
+  highlight: tango
+  config:
+    toc:
+      collapse: section
+      before: |
+       <a href="https://anvilproject.org/" target="_blank"><img src="assets/AnVIL_style/logo-anvil.png" style="width: 80%; padding-left: 15px; padding-top: 8px;"</a>
+      after: |
+       <p style="text-align:center;"> <a href="https://github.com/jhudsl/OTTR_Template" target="blank" > This content was published with</a> <a href="https://bookdown.org/" target="blank"> bookdown by: </a> </p>
+       <p style="text-align:center;"> <a href="http://jhudatascience.org/"> The Johns Hopkins Data Science Lab </a></p>
+       <a href="http://jhudatascience.org/"><img src="https://jhudatascience.org/images/dasl.png" style=" width: 80%; padding-left: 40px; padding-top: 8px; vertical-align: top "</a>
+       <p style="text-align:center; font-size: 12px;"> <a href="https://github.com/rstudio4edu/rstudio4edu-book/"> Style adapted from: rstudio4edu-book </a> <a href ="https://creativecommons.org/licenses/by/2.0/"> (CC-BY 2.0) </a></p>

--- a/style-sets/GDSCN/_output.yml
+++ b/style-sets/GDSCN/_output.yml
@@ -11,6 +11,6 @@ bookdown::gitbook:
        <a href="https://www.gdscn.org/" target="_blank"><img src="assets/GDSCN_style/logo-gdscn.png" style="width: 80%; padding-left: 15px; padding-top: 8px;"</a>
       after: |
        <p style="text-align:center;"> <a href="https://github.com/jhudsl/OTTR_Template" target="blank" > This content was published with</a> <a href="https://bookdown.org/" target="blank"> bookdown by: </a> </p>
-       <p style="text-align:center;"> <a href="http://jhudatascience.org/"> The Johns Hopkins Data Science Lab </a></p>
-       <a href="http://jhudatascience.org/"><img src="https://jhudatascience.org/images/dasl.png" style=" width: 80%; padding-left: 40px; padding-top: 8px; vertical-align: top "</a>
+       <p style="text-align:center;"> <a href="http://hutchdatascience.org/"> The Fred Hutch Data Science Lab </a></p>
+       <a href="http://hutchdatascience.org/"><img src="https://hutchdatascience.org/images/FHDataScienceLab_RecDropped.png" style=" width: 80%; padding-left: 40px; padding-top: 8px; vertical-align: top "</a>
        <p style="text-align:center; font-size: 12px;"> <a href="https://github.com/rstudio4edu/rstudio4edu-book/"> Style adapted from: rstudio4edu-book </a> <a href ="https://creativecommons.org/licenses/by/2.0/"> (CC-BY 2.0) </a></p>

--- a/style-sets/GDSCN_JHU/_output.yml
+++ b/style-sets/GDSCN_JHU/_output.yml
@@ -1,0 +1,16 @@
+bookdown::gitbook:
+  css: assets/GDSCN_style/style.css
+  includes:
+    before_body: assets/GDSCN_style/big-image_gdscn.html
+    after_body: assets/GDSCN_style/footer.html
+  highlight: tango
+  config:
+    toc:
+      collapse: section
+      before: |
+       <a href="https://www.gdscn.org/" target="_blank"><img src="assets/GDSCN_style/logo-gdscn.png" style="width: 80%; padding-left: 15px; padding-top: 8px;"</a>
+      after: |
+       <p style="text-align:center;"> <a href="https://github.com/jhudsl/OTTR_Template" target="blank" > This content was published with</a> <a href="https://bookdown.org/" target="blank"> bookdown by: </a> </p>
+       <p style="text-align:center;"> <a href="http://jhudatascience.org/"> The Johns Hopkins Data Science Lab </a></p>
+       <a href="http://jhudatascience.org/"><img src="https://jhudatascience.org/images/dasl.png" style=" width: 80%; padding-left: 40px; padding-top: 8px; vertical-align: top "</a>
+       <p style="text-align:center; font-size: 12px;"> <a href="https://github.com/rstudio4edu/rstudio4edu-book/"> Style adapted from: rstudio4edu-book </a> <a href ="https://creativecommons.org/licenses/by/2.0/"> (CC-BY 2.0) </a></p>


### PR DESCRIPTION
New content developed for AnVIL and GDSCN should have Hutch Data Science Lab branding. As far as I know, old stuff can retain JHU branding. This PR Changes the branding on the bottom of the Table of Contents to be Hutch themed.