### PR TITLE
add student instructions for launching RStudio

### DIFF
--- a/07-using_platforms_modules.Rmd
+++ b/07-using_platforms_modules.Rmd
@@ -65,6 +65,7 @@ cow::borrow_chapter(
 ```{r, echo = FALSE, results='asis'}
 cow::borrow_chapter(
   doc_path = "child/_child_rstudio_launch.Rmd",
+  branch = "rstudio-launch-conditional"
   repo_name = "jhudsl/AnVIL_Template"
 )
 ```

--- a/07-using_platforms_modules.Rmd
+++ b/07-using_platforms_modules.Rmd
@@ -65,7 +65,7 @@ cow::borrow_chapter(
 ```{r, echo = FALSE, results='asis'}
 cow::borrow_chapter(
   doc_path = "child/_child_rstudio_launch.Rmd",
-  branch = "rstudio-launch-conditional"
+  branch = "rstudio-launch-conditional",
   repo_name = "jhudsl/AnVIL_Template"
 )
 ```

--- a/07-using_platforms_modules.Rmd
+++ b/07-using_platforms_modules.Rmd
@@ -65,7 +65,6 @@ cow::borrow_chapter(
 ```{r, echo = FALSE, results='asis'}
 cow::borrow_chapter(
   doc_path = "child/_child_rstudio_launch.Rmd",
-  branch = "rstudio-launch-conditional",
   repo_name = "jhudsl/AnVIL_Template"
 )
 ```

--- a/08-student_modules.Rmd
+++ b/08-student_modules.Rmd
@@ -19,10 +19,10 @@ These instructions can be customized by setting certain variables before running
 
 - If no variables are set, general purpose instructions with advice about choosing an environment will be used
 - If `audience` is set to "student", it gives more specific instructions.
-  - With no further informationc, it will tell them to use the default RStudio settings
+  - With no further information, it will tell them to use the default RStudio settings
   - If `docker_image` or `startup_script` are set, it will tell them to open the customization dialogue and direct them on how to set the image and/or script.
 
-### Using default environment:
+### Using default RStudio environment:
 
 ```{r, echo = FALSE, results='asis'}
 AnVIL_module_settings <- list(
@@ -36,13 +36,13 @@ cow::borrow_chapter(
 )
 ```
 
-### With variables set:
+### Using custom RStudio environment:
 
 ```{r, echo = FALSE, results='asis'}
 AnVIL_module_settings <- list(
   audience = "student",
-  docker_image = "test docker",
-  startup_script = "test startup script"
+  docker_image = "example docker",
+  startup_script = "example startup script"
 )
 
 cow::borrow_chapter(

--- a/08-student_modules.Rmd
+++ b/08-student_modules.Rmd
@@ -32,7 +32,6 @@ AnVIL_module_settings <- list(
 
 cow::borrow_chapter(
   doc_path = "child/_child_rstudio_launch.Rmd",
-  branch = "rstudio-launch-conditional",
   repo_name = "jhudsl/AnVIL_Template"
 )
 ```
@@ -48,7 +47,6 @@ AnVIL_module_settings <- list(
 
 cow::borrow_chapter(
   doc_path = "child/_child_rstudio_launch.Rmd",
-  branch = "rstudio-launch-conditional",
   repo_name = "jhudsl/AnVIL_Template"
 )
 ```

--- a/08-student_modules.Rmd
+++ b/08-student_modules.Rmd
@@ -26,7 +26,7 @@ These instructions can be customized by setting certain variables before running
 
 ```{r, echo = FALSE, results='asis'}
 AnVIL_module_settings <- list(
-  audience = "student",
+  audience = "student"
 )
 
 cow::borrow_chapter(

--- a/08-student_modules.Rmd
+++ b/08-student_modules.Rmd
@@ -15,12 +15,11 @@ cow::borrow_chapter(
 
 ## Student instructions for launching RStudio
 
-These instructions can be customized by setting certain variables before running `cow::borrow_chapter()`.
+These instructions can be customized by setting certain variables before running `cow::borrow_chapter()`. Developers should create these variables as a list `AnVIL_module_settings`. The following variables can be provided:
 
-- If no variables are set, general purpose instructions with advice about choosing an environment will be used
-- If `audience` is set to "student", it gives more specific instructions.
-  - With no further information, it will tell them to use the default RStudio settings
-  - If `docker_image` or `startup_script` are set, it will tell them to open the customization dialogue and direct them on how to set the image and/or script.
+- `audience` = Defaults to `general`, telling them to use the default RStudio settings. If `audience` is set to `student`, it gives more specific instructions.
+- `docker_image` = Optional, it will tell them to open the customization dialogue and direct them on how to set the image.
+- `startup_script` =  Optional, it will tell them to open the customization dialogue and direct them on how to set the script.
 
 ### Using default RStudio environment:
 

--- a/08-student_modules.Rmd
+++ b/08-student_modules.Rmd
@@ -15,7 +15,9 @@ cow::borrow_chapter(
 
 ## Student instructions for launching RStudio
 
-These instructions can be customized by setting certain variables before running `cow::borrow_chapter()`. Developers should create these variables as a list `AnVIL_module_settings`. The following variables can be provided:
+The module below is specially customized for students, allowing you to give more specific instructions on the settings for their RStudio environment.  There are several other general purpose modules that may also be useful for students (e.g. Pausing RStudio, Deleting RStudio) that can be found in other chapters of this book.
+
+The following instructions can be customized by setting certain variables before running `cow::borrow_chapter()`. Developers should create these variables as a list `AnVIL_module_settings`. The following variables can be provided:
 
 - `audience` = Defaults to `general`, telling them to use the default RStudio settings. If `audience` is set to `student`, it gives more specific instructions.
 - `docker_image` = Optional, it will tell them to open the customization dialogue and direct them on how to set the image.

--- a/08-student_modules.Rmd
+++ b/08-student_modules.Rmd
@@ -13,3 +13,41 @@ cow::borrow_chapter(
 )
 ```
 
+## Student instructions for launching RStudio
+
+These instructions can be customized by setting certain variables before running `cow::borrow_chapter()`.
+
+- If no variables are set, general purpose instructions with advice about choosing an environment will be used
+- If `audience` is set to "student", it gives more specific instructions.
+  - With no further informationc, it will tell them to use the default RStudio settings
+  - If `docker_image` or `startup_script` are set, it will tell them to open the customization dialogue and direct them on how to set the image and/or script.
+
+### Using default environment:
+
+```{r, echo = FALSE, results='asis'}
+AnVIL_module_settings <- list(
+  audience = "student",
+)
+
+cow::borrow_chapter(
+  doc_path = "child/_child_rstudio_launch.Rmd",
+  branch = "rstudio-launch-conditional",
+  repo_name = "jhudsl/AnVIL_Template"
+)
+```
+
+### With variables set:
+
+```{r, echo = FALSE, results='asis'}
+AnVIL_module_settings <- list(
+  audience = "student",
+  docker_image = "test docker",
+  startup_script = "test startup script"
+)
+
+cow::borrow_chapter(
+  doc_path = "child/_child_rstudio_launch.Rmd",
+  branch = "rstudio-launch-conditional",
+  repo_name = "jhudsl/AnVIL_Template"
+)
+```

--- a/child/_child_rstudio_launch.Rmd
+++ b/child/_child_rstudio_launch.Rmd
@@ -8,6 +8,17 @@ if (!exists("AnVIL_module_settings")) {
 }
 ```
 
+```{r, include=FALSE}
+# settings for warning about controlling costs
+# default
+AnVIL_module_settings$text <- "AnVIL is very versatile and can scale up to use very powerful cloud computers. It's very important that you select a cloud computing environment appropriate to your needs to avoid runaway costs.  If you are uncertain, start with the default settings; it is fairly easy to increase your compute resources later, if needed, but harder to scale down."
+
+
+if (AnVIL_module_settings$audience == "student") {
+  AnVIL_module_settings$text <- "AnVIL is very versatile and can scale up to use very powerful cloud computers. It's very important that you select the cloud computing environment described here to avoid runaway costs."
+}
+```
+
 `r if( !(AnVIL_module_settings$audience == "student") ) {'Note that, in order to use RStudio, you must have access to a Terra Workspace with permission to compute (i.e. you must be a "Writer" or "Owner" of the Workspace).'}`
 
 1. Open Terra - use a web browser to go to [`anvil.terra.bio`](https://anvil.terra.bio/)

--- a/child/_child_rstudio_launch.Rmd
+++ b/child/_child_rstudio_launch.Rmd
@@ -1,3 +1,9 @@
+```{r, include = FALSE}
+if (!exists("AnVIL_module_settings")) {
+  AnVIL_module_settings <- list()
+}
+```
+
 `r if( !(AnVIL_module_settings$audience == "student") ) {'Note that, in order to use RStudio, you must have access to a Terra Workspace with permission to compute (i.e. you must be a "Writer" or "Owner" of the Workspace).'}`
 
 1. Open Terra - use a web browser to go to [`anvil.terra.bio`](https://anvil.terra.bio/)

--- a/child/_child_rstudio_launch.Rmd
+++ b/child/_child_rstudio_launch.Rmd
@@ -1,14 +1,3 @@
-```{r, include=FALSE}
-AnVIL_module_settings <- list(
-  audience = "student",
-  docker_image = "test docker",
-  startup_script = "test startup script"
-)
-# audience: 
-#   "general" provides advice on choosing settings (this is the default)
-#   "student" tells the reader what settings to choose
-```
-
 `r if( !(AnVIL_module_settings$audience == "student") ) {'Note that, in order to use RStudio, you must have access to a Terra Workspace with permission to compute (i.e. you must be a "Writer" or "Owner" of the Workspace).'}`
 
 1. Open Terra - use a web browser to go to [`anvil.terra.bio`](https://anvil.terra.bio/)

--- a/child/_child_rstudio_launch.Rmd
+++ b/child/_child_rstudio_launch.Rmd
@@ -1,58 +1,211 @@
-Note that, in order to use RStudio, you must have access to a Terra Workspace with permission to compute (i.e. you must be a "Writer" or "Owner" of the Workspace).
+```{r, include=FALSE}
+AnVIL_module_settings <- list(
+  audience = "student",
+  docker_image = "test docker",
+  startup_script = "test startup script"
+)
+# audience: 
+#   "general" provides advice on choosing settings (this is the default)
+#   "student" tells the reader what settings to choose
+```
+
+`r if( !(AnVIL_module_settings$audience == "student") ) {'Note that, in order to use RStudio, you must have access to a Terra Workspace with permission to compute (i.e. you must be a "Writer" or "Owner" of the Workspace).'}`
+
+1. Open Terra - use a web browser to go to [`anvil.terra.bio`](https://anvil.terra.bio/)
+
+1. In the drop-down menu on the left, navigate to "Workspaces". Click the triple bar in the top left corner to access the menu. Click "Workspaces".
+
+    ```{r, echo=FALSE, out.width = '100%', fig.alt='Screenshot of Terra drop-down menu.  The "hamburger" button to extend the drop-down menu is highlighted, and the menu item "Workspaces" is highlighted.'}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1a35Mb8f0M-bQkBcHa1cyQc6YxXoBLtExCz96nv08vkA/edit#slide=id.g117989bd49c_0_150")
+    ```
 
 1. Click on the name of your Workspace. You should be routed to a link that looks like: `https://anvil.terra.bio/#workspaces/<billing-project>/<workspace-name>`.
 
-1. On the top right, Click the gear icon to access your Cloud Environment options.
+1. Click on the cloud icon on the far right to access your Cloud Environment options.
 
-    ```{r, echo=FALSE, fig.alt='Screenshot of the newly created Workspace. The gear icon to create a new cloud environment is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/1eypYLLqD11-NwHLs4adGpcuSB07dYEJfAaALSMvgzqw/edit#slide=id.gdde5ec9a4d_1_34")
+    ```{r, echo=FALSE, out.width = '100%', fig.alt='Screenshot of a Terra Workspace. The cloud icon to create a new cloud environment is highlighted.'}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1a35Mb8f0M-bQkBcHa1cyQc6YxXoBLtExCz96nv08vkA/edit#slide=id.g14ea2db115d_0_22")
     ```
 
-1. You will see a list of costs because it costs a small amount of money to use cloud computing. Click "CUSTOMIZE".
+1. In the dialogue box, click the "Settings" button under RStudio
 
-    ```{r, echo=FALSE, fig.alt='Screenshot of the cloud environment popout menu. The "Customize" button is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/1eypYLLqD11-NwHLs4adGpcuSB07dYEJfAaALSMvgzqw/edit#slide=id.gdde5ec9a4d_1_50")
+    ```{r, echo=FALSE, out.width = '100%', fig.alt='Screenshot of the Cloud Environment Details dialogue box. The Settings button under RStudio is highlighted.'}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1a35Mb8f0M-bQkBcHa1cyQc6YxXoBLtExCz96nv08vkA/edit#slide=id.g14ea2db115d_0_18")
     ```
 
-1. Click on the first drop down menu to see what other software configurations are available.
+1. You will see some details about the default RStudio cloud environment, and a list of costs because it costs a small amount of money to use cloud computing.
 
-    ```{r, echo=FALSE, fig.alt='Screenshot of the cloud environment popout menu. The first dropdown menu for options, the Application configuration menu, is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/1eypYLLqD11-NwHLs4adGpcuSB07dYEJfAaALSMvgzqw/edit#slide=id.gdde5ec9a4d_1_11")
+    ```{r, echo=FALSE, out.width = '100%', fig.alt='Screenshot of the RStudio Cloud Environment dialogue box. The cost to run the environment is highlighted.'}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1a35Mb8f0M-bQkBcHa1cyQc6YxXoBLtExCz96nv08vkA/edit#slide=id.g14ea2db115d_0_35")
     ```
 
-1. Scroll down and select RStudio from the Community-Maintained RStudio Environments section. **NOTE**: AnVIL is very versatile and can scale up to use very powerful cloud computers. It's very important that you select a cloud computing environment appropriate to your needs to avoid runaway costs.  If you are uncertain, start with the default settings; it is fairly easy to increase your compute resources later, if needed, but harder to scale down.
+```{r, include=FALSE}
+# settings for instructions about using the default RStudio configuration
+# default settings
+AnVIL_module_settings$include <- TRUE
+AnVIL_module_settings$text <- '1. If you are uncertain about what you need, the default configuration is a reasonable, cost-conservative choice.  It is fairly easy to increase your compute resources later, if needed, but harder to scale down. Click the “Create” button.'
+# for students
+if (AnVIL_module_settings$audience == "student") {
+  
+  # if there are no custom settings, include this slide
+  if (all( is.null(c(AnVIL_module_settings$docker_image,
+                    AnVIL_module_settings$startup_script)) )) {
+    AnVIL_module_settings$include <- TRUE
+    AnVIL_module_settings$text <- '1. Click the "CREATE" button.'
+  }
+  # if there *are* custom settings, then exclude this slide
+  else {
+    AnVIL_module_settings$include <- FALSE
+  }
+}
+```
 
-    ```{r, echo=FALSE, fig.alt='Screenshot of the Application configuration menu. The community maintained RStudio environment is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/1eypYLLqD11-NwHLs4adGpcuSB07dYEJfAaALSMvgzqw/edit#slide=id.ge08067d6e2_0_0")
+```{r, echo=FALSE, results='asis', eval=AnVIL_module_settings$include}
+cat(AnVIL_module_settings$text)
+```
+
+    ```{r, echo=FALSE, out.width = '100%', eval=AnVIL_module_settings$include, fig.alt='Screenshot of the RStudio Cloud Environment dialogue box. The "CREATE" button is highlighted.'}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1a35Mb8f0M-bQkBcHa1cyQc6YxXoBLtExCz96nv08vkA/edit#slide=id.g14ea2db115d_0_41")
     ```
 
-1. Leave everything else as-is. To create your RStudio Cloud Environment, click on the “CREATE” button.
+```{r, include=FALSE}
+# settings for instructions about opening the RStudio custom configuration menu
+# default settings
+AnVIL_module_settings$include <- TRUE
+AnVIL_module_settings$text <- '1. Otherwise, click “CUSTOMIZE” to modify the environment for your needs.'
+# for students
+if (AnVIL_module_settings$audience == "student") {
+  
+  # if there are no custom settings, exclude this slide
+  if (all( is.null(c(AnVIL_module_settings$docker_image,
+                    AnVIL_module_settings$startup_script)) )) {
+    AnVIL_module_settings$include <- FALSE
+  }
+  # if there *are* custom settings, include this slide
+  else {
+    AnVIL_module_settings$include <- TRUE
+    AnVIL_module_settings$text <- '1. Click "CUSTOMIZE" to adjust the settings for your environment.'
+  }
+}
+```
 
-    ```{r, echo=FALSE, fig.alt='Screenshot of the Application configuration menu. The "Create" button is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/1eypYLLqD11-NwHLs4adGpcuSB07dYEJfAaALSMvgzqw/edit#slide=id.ge08067d6e2_0_34")
+```{r, echo=FALSE, results='asis', eval=AnVIL_module_settings$include}
+cat(AnVIL_module_settings$text)
+```
+
+    ```{r, echo=FALSE, out.width = '100%', eval=AnVIL_module_settings$include, fig.alt='Screenshot of the RStudio Cloud Environment dialogue box. The "CUSTOMIZE" button is highlighted.'}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1a35Mb8f0M-bQkBcHa1cyQc6YxXoBLtExCz96nv08vkA/edit#slide=id.g14ea2db115d_0_48")
     ```
 
-1. Your Cloud Environment will be available in a few minutes after the cloud resources are provisioned and your software starts up. The upper right corner displays the status and should say “Creating” while resources are being provisioned.
+```{r, include=FALSE}
+# settings for instructions about using a custom docker image
+# default settings
+AnVIL_module_settings$include <- FALSE
+AnVIL_module_settings$text <- NULL
+# for students
+if (AnVIL_module_settings$audience == "student") {
+  
+  # if there is a custom docker image, include this slide
+  if ( !is.null(AnVIL_module_settings$docker_image) ) {
+    AnVIL_module_settings$include <- TRUE
+    AnVIL_module_settings$text <- '1. Under "Application configuration" you will see a dropdown menu.  You can also enter text here.  Copy the following link into the box:'
+  }
+  # otherwise exclude this slide
+  else {
+    AnVIL_module_settings$include <- FALSE
+  }
+}
+```
 
-    ```{r, echo=FALSE, fig.alt='Screenshot of the Workspace page. A cloud environment for RStudio is being created. The loading icon on the top right of the page is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/1eypYLLqD11-NwHLs4adGpcuSB07dYEJfAaALSMvgzqw/edit#slide=id.ge08067d6e2_0_6")
+```{r, echo=FALSE, results='asis', eval=AnVIL_module_settings$include}
+cat(AnVIL_module_settings$text)
+```
+
+    ``r if(AnVIL_module_settings$include){AnVIL_module_settings$docker_image}``
+
+    ```{r, echo=FALSE, out.width = '100%', eval=AnVIL_module_settings$include, fig.alt='Screenshot of the RStudio Cloud Environment customization dialogue box. The dropdown menu labeled "Application configuration" is highlighted.'}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1a35Mb8f0M-bQkBcHa1cyQc6YxXoBLtExCz96nv08vkA/edit#slide=id.g14ea2db115d_0_65")
     ```
 
-1. After a few minutes, you will see the status change to “Running”.
+```{r, include=FALSE}
+# settings for instructions about using a custom startup script
+# default settings
+AnVIL_module_settings$include <- FALSE
+AnVIL_module_settings$text <- NULL
+# for students
+if (AnVIL_module_settings$audience == "student") {
+  
+  # if there is a custom docker image, include this slide
+  if ( !is.null(AnVIL_module_settings$startup_script) ) {
+    AnVIL_module_settings$include <- TRUE
+    AnVIL_module_settings$text <- '1. Under "Startup script" you will see textbox.  Copy the following link into the box:'
+  }
+  # otherwise exclude this slide
+  else {
+    AnVIL_module_settings$include <- FALSE
+  }
+}
+```
 
-    ```{r, echo=FALSE, fig.alt='Screenshot of the Workspace page. A cloud environment for RStudio has been created. The icon on the top right showing that the cloud environment is running is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/1eypYLLqD11-NwHLs4adGpcuSB07dYEJfAaALSMvgzqw/edit#slide=id.ge08067d6e2_0_10")
+```{r, echo=FALSE, results='asis', eval=AnVIL_module_settings$include}
+cat(AnVIL_module_settings$text)
+```
+
+    ``r if(AnVIL_module_settings$include){AnVIL_module_settings$startup_script}``
+
+    ```{r, echo=FALSE, out.width = '100%', eval=AnVIL_module_settings$include, fig.alt='Screenshot of the RStudio Cloud Environment customization dialogue box. The textbox labeled "Startup script" is highlighted.'}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1a35Mb8f0M-bQkBcHa1cyQc6YxXoBLtExCz96nv08vkA/edit#slide=id.g14ea2db115d_0_78")
     ```
 
-1. Click on the “R” icon to launch RStudio.
+```{r, include=FALSE}
+# settings for instructions to click "Create" from RStudio custom configuration
+# default settings
+AnVIL_module_settings$include <- FALSE
+AnVIL_module_settings$text <- NULL
+# for students
+if (AnVIL_module_settings$audience == "student") {
+  
+  # if there are no custom settings, exclude this slide
+  if (all( is.null(c(AnVIL_module_settings$docker_image,
+                    AnVIL_module_settings$startup_script)) )) {
+    AnVIL_module_settings$include <- FALSE
+  }
+  # if there *are* custom settings, include this slide
+  else {
+    AnVIL_module_settings$include <- TRUE
+    AnVIL_module_settings$text <- '1. Leave everything else as-is. To create your RStudio Cloud Environment, click on the “CREATE” button.'
+  }
+}
+```
 
-    ```{r, echo=FALSE, fig.alt='Screenshot of the Workspace page. A cloud environment for RStudio has been created. The R button that launches the RStudio interface is highlighted.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/1eypYLLqD11-NwHLs4adGpcuSB07dYEJfAaALSMvgzqw/edit#slide=id.ge08067d6e2_0_43")
+```{r, echo=FALSE, results='asis', eval=AnVIL_module_settings$include}
+cat(AnVIL_module_settings$text)
+```
+
+    ```{r, echo=FALSE, out.width = '100%', eval=AnVIL_module_settings$include, fig.alt='Screenshot of the RStudio Cloud Environment customization dialogue box. The "CREATE" button is highlighted.'}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1a35Mb8f0M-bQkBcHa1cyQc6YxXoBLtExCz96nv08vkA/edit#slide=id.g14ea2db115d_0_84")
+    ```
+
+1. The dialogue box will close and you will be returned to your Workspace.  You can see the status of your cloud environment by hovering over the RStudio logo.  It will take a few minutes for Terra to request computers and install software.
+
+    ```{r, echo=FALSE, out.width = '100%', fig.alt='Screenshot of a Terra Workspace. The hovertext for the RStudio icon is highlighted, and indicates that the status of the environment is "Creating".'}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1a35Mb8f0M-bQkBcHa1cyQc6YxXoBLtExCz96nv08vkA/edit#slide=id.g14ea2db115d_0_91")
+    ```
+
+1. When your environment is ready, its status will change to “Running”.  Click on the RStudio logo to open a new dialogue box that will let you launch RStudio.
+
+    ```{r, echo=FALSE, out.width = '100%', fig.alt='Screenshot of a Terra Workspace. The hovertext for the RStudio icon is highlighted, and indicates that the status of the environment is "Running".'}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1a35Mb8f0M-bQkBcHa1cyQc6YxXoBLtExCz96nv08vkA/edit#slide=id.g14ea2db115d_0_95")
+    ```
+    
+1. Click the launch icon to open RStudio.  This is also where you can pause, modify, or delete your environment when needed.
+
+    ```{r, echo=FALSE, out.width = '100%', fig.alt='Screenshot of the RStudio Environment Details dialogue box. The "Open" button is highlighted.'}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1a35Mb8f0M-bQkBcHa1cyQc6YxXoBLtExCz96nv08vkA/edit#slide=id.g14ea2db115d_0_99")
     ```
 
 1. You should now see the RStudio interface with information about the version printed to the console.
 
-    ```{r, echo=FALSE, fig.alt='Screenshot of the RStudio environment interface.'}
-ottrpal::include_slide("https://docs.google.com/presentation/d/1eypYLLqD11-NwHLs4adGpcuSB07dYEJfAaALSMvgzqw/edit#slide=id.ge08067d6e2_0_14")
+    ```{r, echo=FALSE, out.width = '100%', fig.alt='Screenshot of the RStudio environment interface.'}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1a35Mb8f0M-bQkBcHa1cyQc6YxXoBLtExCz96nv08vkA/edit#slide=id.g14ea2db115d_0_103")
     ```
-

--- a/child/_child_rstudio_launch.Rmd
+++ b/child/_child_rstudio_launch.Rmd
@@ -1,6 +1,8 @@
 ```{r, include = FALSE}
 if (!exists("AnVIL_module_settings")) {
-  AnVIL_module_settings <- list()
+  AnVIL_module_settings <- list(
+    audience = "general"
+    )
 }
 ```
 

--- a/child/_child_rstudio_launch.Rmd
+++ b/child/_child_rstudio_launch.Rmd
@@ -3,6 +3,8 @@ if (!exists("AnVIL_module_settings")) {
   AnVIL_module_settings <- list(
     audience = "general"
     )
+} else if (is.null(AnVIL_module_settings$audience)) {
+  AnVIL_module_settings$audience = "general"
 }
 ```
 

--- a/child/_child_rstudio_launch.Rmd
+++ b/child/_child_rstudio_launch.Rmd
@@ -19,6 +19,10 @@ if (AnVIL_module_settings$audience == "student") {
 }
 ```
 
+:::{.warning}
+`r AnVIL_module_settings$text`
+:::
+
 `r if( !(AnVIL_module_settings$audience == "student") ) {'Note that, in order to use RStudio, you must have access to a Terra Workspace with permission to compute (i.e. you must be a "Writer" or "Owner" of the Workspace).'}`
 
 1. Open Terra - use a web browser to go to [`anvil.terra.bio`](https://anvil.terra.bio/)

--- a/child/_child_rstudio_launch.Rmd
+++ b/child/_child_rstudio_launch.Rmd
@@ -120,7 +120,9 @@ if (AnVIL_module_settings$audience == "student") {
 cat(AnVIL_module_settings$text)
 ```
 
-    ``r if(AnVIL_module_settings$include){AnVIL_module_settings$docker_image}``
+    ```{r, echo=FALSE, results='asis', eval=AnVIL_module_settings$include}
+     cat(paste("`", AnVIL_module_settings$docker_image, "`"))
+    ```
 
     ```{r, echo=FALSE, out.width = '100%', eval=AnVIL_module_settings$include, fig.alt='Screenshot of the RStudio Cloud Environment customization dialogue box. The dropdown menu labeled "Application configuration" is highlighted.'}
 ottrpal::include_slide("https://docs.google.com/presentation/d/1a35Mb8f0M-bQkBcHa1cyQc6YxXoBLtExCz96nv08vkA/edit#slide=id.g14ea2db115d_0_65")
@@ -150,7 +152,9 @@ if (AnVIL_module_settings$audience == "student") {
 cat(AnVIL_module_settings$text)
 ```
 
-    ``r if(AnVIL_module_settings$include){AnVIL_module_settings$startup_script}``
+    ```{r, echo=FALSE, results='asis', eval=AnVIL_module_settings$include}
+     cat(paste("`", AnVIL_module_settings$startup_script, "`"))
+    ```
 
     ```{r, echo=FALSE, out.width = '100%', eval=AnVIL_module_settings$include, fig.alt='Screenshot of the RStudio Cloud Environment customization dialogue box. The textbox labeled "Startup script" is highlighted.'}
 ottrpal::include_slide("https://docs.google.com/presentation/d/1a35Mb8f0M-bQkBcHa1cyQc6YxXoBLtExCz96nv08vkA/edit#slide=id.g14ea2db115d_0_78")


### PR DESCRIPTION
"Programming" the markdown content opens up some interesting possibilities, which I've been experimenting with :)

This PR has instructions on using a custom docker image or startup script that are conditionally included depending on whether you set a couple of variable before running `borrow_chapter()`

I've also set it up to use a single `_child_rstudio_launch.Rmd` (as opposed to having a separate version for students), which then modifies itself based on the audience - students get more specific instructions; general audience gets more advice on how to make their own decisions.

The general audience version can be seen in Chapter 7.7; the student version can be seen in Chapter 8.2.

Having both audiences in a single child document means:
- We only need to maintain one version of the instructions and screenshots
- But, the logic is a bit more complicated, so the .Rmd is more confusing for anyone who wants to edit it later.

Alternatively we could stick with something like the cloning instructions (#170), with separate student vs. general purpose child documents.  I've been having fun seeing what's possible to automate, but am also fine with some manual repetition for the sake of simplicity.  Still feeling out where to draw the line.

Thoughts?
