### PR TITLE
Improve GSDCN description in index.Rmd

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -13,7 +13,7 @@ favicon: assets/AnVIL_style/anvil_favicon.ico
 
 # About this Book {-}
 
-This book is part of a series of books for the Genomic Data Science Analysis, Visualization, and Informatics Lab-space (AnVIL) of the National Human Genome Research Institute (NHGRI). Learn more about AnVIL by visiting `https://anvilproject.org` or reading the [article in Cell Genomics](https://www.sciencedirect.com/science/article/pii/S2666979X21001063).
+This book is part of a series of books for the Genomic Data Science Analysis, Visualization, and Informatics Lab-space (AnVIL) of the National Human Genome Research Institute (NHGRI). Learn more about AnVIL by visiting https://anvilproject.org or reading the [article in Cell Genomics](https://www.sciencedirect.com/science/article/pii/S2666979X21001063).
 
 ## Skills Level {-} 
 

--- a/style-sets/GDSCN/index.Rmd
+++ b/style-sets/GDSCN/index.Rmd
@@ -12,7 +12,7 @@ favicon: assets/GDSCN_style/gdscn_favicon.ico
 
 # About this Course {-}
 
-This course is part of a series of courses for the [The Genomic Data Science Community Network (GDSCN)](https://www.gdscn.org/home) is a group of educators gathered with the aim to bring genomic data science education to students at diverse institutions. 
+This course is part of a collection of curriculum developed through the The Genomic Data Science Community Network (GDSCN). GDSCN works towards a vision where researchers, educators, and students from diverse backgrounds are able to fully participate in genomic data science research.  Learn more about GDSCN by visiting `https://www.gdscn.org/home` or reading the [article in Genome Research](https://doi.org/10.1101/gr.276496.121).
 
 ## Skills Level {-} 
 

--- a/style-sets/GDSCN/index.Rmd
+++ b/style-sets/GDSCN/index.Rmd
@@ -12,7 +12,7 @@ favicon: assets/GDSCN_style/gdscn_favicon.ico
 
 # About this Course {-}
 
-This course is part of a collection of teaching resources developed through the The Genomic Data Science Community Network (GDSCN). GDSCN works towards a vision where researchers, educators, and students from diverse backgrounds are able to fully participate in genomic data science research.  Learn more about GDSCN by visiting `https://www.gdscn.org/home` or reading the [article in Genome Research](https://doi.org/10.1101/gr.276496.121).
+This course is part of a collection of teaching resources developed through the the *Genomic Data Science Community Network* (GDSCN). GDSCN works towards a vision where researchers, educators, and students from diverse backgrounds are able to fully participate in genomic data science research.  Learn more about GDSCN by visiting https://www.gdscn.org/home or reading the [article in Genome Research](https://doi.org/10.1101/gr.276496.121).
 
 ## Skills Level {-} 
 

--- a/style-sets/GDSCN/index.Rmd
+++ b/style-sets/GDSCN/index.Rmd
@@ -12,7 +12,7 @@ favicon: assets/GDSCN_style/gdscn_favicon.ico
 
 # About this Course {-}
 
-This course is part of a collection of curriculum developed through the The Genomic Data Science Community Network (GDSCN). GDSCN works towards a vision where researchers, educators, and students from diverse backgrounds are able to fully participate in genomic data science research.  Learn more about GDSCN by visiting `https://www.gdscn.org/home` or reading the [article in Genome Research](https://doi.org/10.1101/gr.276496.121).
+This course is part of a collection of teaching resources developed through the The Genomic Data Science Community Network (GDSCN). GDSCN works towards a vision where researchers, educators, and students from diverse backgrounds are able to fully participate in genomic data science research.  Learn more about GDSCN by visiting `https://www.gdscn.org/home` or reading the [article in Genome Research](https://doi.org/10.1101/gr.276496.121).
 
 ## Skills Level {-} 
 


### PR DESCRIPTION
Working on #152 , this PR
- updates the blurb a bit, using language from the website
- links to the article

Here's a screenshot, since this doesn't get automatically rendered.
<img width="1174" alt="Screen Shot 2022-11-08 at 7 47 18 PM" src="https://user-images.githubusercontent.com/13210811/200708656-21ca700a-1d1f-4615-a90a-62dfa3f99f34.png">

I also noticed we needed a small change to the AnVIL version of `index.Rmd` - the link wasn't rendering as a link.  I just took the backticks off, but we could alternatively do 
```
[`https://anvilproject.org`](https://anvilproject.org)
```
 if we want it styled as code


