### PR TITLE
Update `child_terra_create_billing_project`

### DIFF
--- a/05-billing_modules.Rmd
+++ b/05-billing_modules.Rmd
@@ -39,7 +39,7 @@ The demo below has the reminders included
 ```{r, echo = FALSE, results='asis'}
 # Specify settings
 AnVIL_module_settings <- list(
-  google_billing = TRUE,
+  google_billing = TRUE
 )
 cow::borrow_chapter(
   doc_path = "child/_child_terra_create_billing_project.Rmd",

--- a/05-billing_modules.Rmd
+++ b/05-billing_modules.Rmd
@@ -28,22 +28,10 @@ cow::borrow_chapter(
 
 ## Create Terra Billing Project
 
-This module can be modified depending on the audience:
-
-- If `AnVIL_module_settings$google_billing` is set to `TRUE`, it assumes the audience is also involved in Google Billing and reminds them to use the same Google Account to access Terra
-- If `AnVIL_module_settings$google_billing` is `FALSE` or absent, the reminders are not included
-
-The demo below has the reminders included
-
 :::: {.borrowed_chunk}
 ```{r, echo = FALSE, results='asis'}
-# Specify settings
-AnVIL_module_settings <- list(
-  google_billing = TRUE
-)
 cow::borrow_chapter(
   doc_path = "child/_child_terra_create_billing_project.Rmd",
-  branch = "update-child-create-billing-project",
   repo_name = "jhudsl/AnVIL_Template"
 )
 ```

--- a/05-billing_modules.Rmd
+++ b/05-billing_modules.Rmd
@@ -6,55 +6,79 @@ Modules about billing and Billing Projects on Google Cloud Platform and Terra.
 
 ## Create Google Billing Account
 
+:::: {.borrowed_chunk}
 ```{r, echo = FALSE, results='asis'}
 cow::borrow_chapter(
   doc_path = "child/_child_google_billing_create_account.Rmd",
   repo_name = "jhudsl/AnVIL_Template"
 )
 ```
+::::
 
 ## Add Terra to Google Billing Account
 
+:::: {.borrowed_chunk}
 ```{r, echo = FALSE, results='asis'}
 cow::borrow_chapter(
   doc_path = "child/_child_google_billing_add_terra.Rmd",
   repo_name = "jhudsl/AnVIL_Template"
 )
 ```
+::::
 
 ## Create Terra Billing Project
 
+This module can be modified depending on the audience:
+
+- If `AnVIL_module_settings$google_billing` is set to `TRUE`, it assumes the audience is also involved in Google Billing and reminds them to use the same Google Account to access Terra
+- If `AnVIL_module_settings$google_billing` is `FALSE` or absent, the reminders are not included
+
+The demo below has the reminders included
+
+:::: {.borrowed_chunk}
 ```{r, echo = FALSE, results='asis'}
+# Specify settings
+AnVIL_module_settings <- list(
+  google_billing = TRUE,
+)
 cow::borrow_chapter(
   doc_path = "child/_child_terra_create_billing_project.Rmd",
+  branch = "update-child-create-billing-project",
   repo_name = "jhudsl/AnVIL_Template"
 )
 ```
+::::
 
 ## Add Members to Google Billing Account
 
+:::: {.borrowed_chunk}
 ```{r, echo = FALSE, results='asis'}
 cow::borrow_chapter(
   doc_path = "child/_child_google_billing_add_member.Rmd",
   repo_name = "jhudsl/AnVIL_Template"
 )
 ```
+::::
 
 ## Set Alerts for Google Billing
 
+:::: {.borrowed_chunk}
 ```{r, echo = FALSE, results='asis'}
 cow::borrow_chapter(
   doc_path = "child/_child_google_billing_set_alerts.Rmd",
   repo_name = "jhudsl/AnVIL_Template"
 )
 ```
+::::
 
 ## View Spend for Google Billing
 
+:::: {.borrowed_chunk}
 ```{r, echo = FALSE, results='asis'}
 cow::borrow_chapter(
   doc_path = "child/_child_google_billing_view_spend.Rmd",
   repo_name = "jhudsl/AnVIL_Template"
 )
 ```
+::::
 

--- a/child/_child_terra_create_billing_project.Rmd
+++ b/child/_child_terra_create_billing_project.Rmd
@@ -33,3 +33,7 @@ ottrpal::include_slide("https://docs.google.com/presentation/d/1POwxqv4p6AfPHJlN
     ```
 
 The page doesn't always update as soon as the Billing Project is created.  If it's been a couple of minutes and you don't see a change, try refreshing the page.
+
+```{r, include = FALSE}
+AnVIL_module_settings <<- NULL
+```

--- a/child/_child_terra_create_billing_project.Rmd
+++ b/child/_child_terra_create_billing_project.Rmd
@@ -1,6 +1,6 @@
 1. [Launch Terra](https://anvil.terra.bio/#workspaces) and sign in with your Google account.  If this is your first time logging in to Terra, you will need to accept the Terms of Service.
 
-1. In the drop-down menu on the left, navigate to "Billing". Click the triple bar in the top left corner to access the menu. Click the arrow next to your name to expand the menu, then click "Billing".
+1. In the drop-down menu on the left, navigate to "Billing". Click the triple bar in the top left corner to access the menu. Click the arrow next to your name to expand the menu, then click "Billing".  You can also navigate there directly with this link: https://anvil.terra.bio/#billing
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the Terra drop-down menu.  Three items are highlighted: 1) the "hamburger" button for extending the drop-down menu, 2) the arrow next to your username, for extending the drop-down submenu, and 3) the submenu item "Billing".'}
 ottrpal::include_slide("https://docs.google.com/presentation/d/1POwxqv4p6AfPHJlN9VNq0TaT44fA2RAFSpIERIMHdWU/edit#slide=id.g116f8d759be_0_2")

--- a/child/_child_terra_create_billing_project.Rmd
+++ b/child/_child_terra_create_billing_project.Rmd
@@ -23,7 +23,3 @@ ottrpal::include_slide("https://docs.google.com/presentation/d/1POwxqv4p6AfPHJlN
     ```
 
 The page doesn't always update as soon as the Billing Project is created.  If it's been a couple of minutes and you don't see a change, try refreshing the page.
-
-```{r, include = FALSE}
-AnVIL_module_settings <<- NULL
-```

--- a/child/_child_terra_create_billing_project.Rmd
+++ b/child/_child_terra_create_billing_project.Rmd
@@ -1,14 +1,4 @@
-```{r, include = FALSE}
-if (!exists("AnVIL_module_settings")) {
-  AnVIL_module_settings <- list(
-    google_billing = TRUE
-    )
-} else if (is.null(AnVIL_module_settings$google_billing)) {
-  AnVIL_module_settings$audience = TRUE
-}
-```
-
-1. [Launch Terra](https://anvil.terra.bio/#workspaces) and sign in with your Google account.  `r if(AnVIL_module_settings$google_billing) {'**Make sure to use the same Google account that you used to set up Google Billing.**'}`  If this is your first time logging in to Terra, you will need to accept the Terms of Service.
+1. [Launch Terra](https://anvil.terra.bio/#workspaces) and sign in with your Google account.  If this is your first time logging in to Terra, you will need to accept the Terms of Service.
 
 1. In the drop-down menu on the left, navigate to "Billing". Click the triple bar in the top left corner to access the menu. Click the arrow next to your name to expand the menu, then click "Billing".
 
@@ -16,7 +6,7 @@ if (!exists("AnVIL_module_settings")) {
 ottrpal::include_slide("https://docs.google.com/presentation/d/1POwxqv4p6AfPHJlN9VNq0TaT44fA2RAFSpIERIMHdWU/edit#slide=id.g116f8d759be_0_2")
     ```
 
-1. On the Billing page, click the "+ CREATE" button to create a new Billing Project. If prompted, select the Google account to use.  `r if(AnVIL_module_settings$google_billing) {'Make sure to use the same Google account that you used to set up Google Billing.'}` If prompted, give Terra permission to manage Google Cloud Platform billing accounts.
+1. On the Billing page, click the "+ CREATE" button to create a new Billing Project. If prompted, select the Google account to use.  If prompted, give Terra permission to manage Google Cloud Platform billing accounts.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the Terra Billing Page.  The "plus" button next to "Billing Projects" is highlighted.'}
 ottrpal::include_slide("https://docs.google.com/presentation/d/1POwxqv4p6AfPHJlN9VNq0TaT44fA2RAFSpIERIMHdWU/edit#slide=id.g116f8d759be_0_149")

--- a/child/_child_terra_create_billing_project.Rmd
+++ b/child/_child_terra_create_billing_project.Rmd
@@ -1,4 +1,14 @@
-1. [Launch Terra](https://anvil.terra.bio/#workspaces) and sign in with your Google account.  **Make sure to use the same Google account that you used to set up Google Billing.** If this is your first time logging in to Terra, you will need to accept the Terms of Service.
+```{r, include = FALSE}
+if (!exists("AnVIL_module_settings")) {
+  AnVIL_module_settings <- list(
+    google_billing = TRUE
+    )
+} else if (is.null(AnVIL_module_settings$google_billing)) {
+  AnVIL_module_settings$audience = TRUE
+}
+```
+
+1. [Launch Terra](https://anvil.terra.bio/#workspaces) and sign in with your Google account.  `r if(AnVIL_module_settings$google_billing) {'**Make sure to use the same Google account that you used to set up Google Billing.**'}`  If this is your first time logging in to Terra, you will need to accept the Terms of Service.
 
 1. In the drop-down menu on the left, navigate to "Billing". Click the triple bar in the top left corner to access the menu. Click the arrow next to your name to expand the menu, then click "Billing".
 
@@ -6,21 +16,20 @@
 ottrpal::include_slide("https://docs.google.com/presentation/d/1POwxqv4p6AfPHJlN9VNq0TaT44fA2RAFSpIERIMHdWU/edit#slide=id.g116f8d759be_0_2")
     ```
 
-1. On the Billing page, click the "+ CREATE" button to create a new Billing Project. If prompted, select the Google account to use.  Make sure to use the same Google account that you used to set up Google Billing. If prompted, give Terra permission to manage Google Cloud Platform billing accounts.
+1. On the Billing page, click the "+ CREATE" button to create a new Billing Project. If prompted, select the Google account to use.  `r if(AnVIL_module_settings$google_billing) {'Make sure to use the same Google account that you used to set up Google Billing.'}` If prompted, give Terra permission to manage Google Cloud Platform billing accounts.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the Terra Billing Page.  The "plus" button next to "Billing Projects" is highlighted.'}
 ottrpal::include_slide("https://docs.google.com/presentation/d/1POwxqv4p6AfPHJlN9VNq0TaT44fA2RAFSpIERIMHdWU/edit#slide=id.g116f8d759be_0_149")
     ```
 
-1. Enter a unique name for your Terra Billing Project and select the appropriate Google Billing Account. The name of the Terra Billing Project must:
+1. Enter a **unique** name for your Terra Billing Project and select the appropriate Google Billing Account. The name of the Terra Billing Project must:
     + Only contain lowercase letters, numbers and hyphens
     + Start with a lowercase letter
     + Not end with a hyphen
     + Be between 6 and 30 characters
-    + Be unique across all Google Billing Projects
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the Terra Add Billing Project dialog box.'}
 ottrpal::include_slide("https://docs.google.com/presentation/d/1POwxqv4p6AfPHJlN9VNq0TaT44fA2RAFSpIERIMHdWU/edit#slide=id.g116f8d759be_0_293")
     ```
 
-The page doesn't always update as soon as the billing project is created.  If it's been a couple of minutes and you don't see a change, try refreshing the page.
+The page doesn't always update as soon as the Billing Project is created.  If it's been a couple of minutes and you don't see a change, try refreshing the page.


### PR DESCRIPTION
Look at the markdown, the rendered preview is out-of-date.  Sorry, this PR got a bit messy for something that ended up being a really minor edit after I changed my mind, haha.

(Started this PR because it was awkward to have a warning about using the right Google Account for somebody who isn't involved in the Google side of things)

~Adds a setting to modify the text depending on whether the intended audience is involved in Google Billing, or is just dealing with the Terra side of things:~

~Adds reminders to "Make sure to use the same Google account that you used to set up Google Billing." iff `AnVIL_module_settings$google_billing is TRUE`~

~For PIs, etc. it's useful to have those reminders.
For lab managers, instructors, etc. it's just confusing.~

Eh, I think this adds unnecessary complexity.  I just deleted the sentence.  If particular personas need the reminder (e.g. PIs), it can be added outside the module in a callout box.

Went ahead and added `.borrow_chunk` boxes around the billing modules since I was editing the chapter anyway.