### PR TITLE
generalize google_billing_create_account

### DIFF
--- a/child/_child_google_billing_create_account.Rmd
+++ b/child/_child_google_billing_create_account.Rmd
@@ -8,7 +8,7 @@ ottrpal::include_slide("https://docs.google.com/presentation/d/1tGpzZaQxoTAcxs_n
 
 1. Follow the instructions to sign up for a Billing Account and get your credits. 
 
-1. Choose “Individual Account”. This “billing account” is just for managing billing, so you don’t need to be able to add your lab members. You will need to give either a credit card or bank account for security. Don't worry! **You won't be billed until you explicitly turn on automatic billing**.
+1. Choose “Individual Account”. This “billing account” is just for managing billing, so you don’t need to be able to add your team members. You will need to give either a credit card or bank account for security. Don't worry! **You won't be billed until you explicitly turn on automatic billing**.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Billing Account Setup, with "Individual Account" highlighted.  Also highlighted is text stating "You won\'t be charged unless you manually upgrade to a paid account."'}
 ottrpal::include_slide("https://docs.google.com/presentation/d/1tGpzZaQxoTAcxs_nyyNL2FOqypjEofEnMVpBtZiAw4A/edit#slide=id.g116ca06e27d_0_146")
@@ -20,7 +20,7 @@ ottrpal::include_slide("https://docs.google.com/presentation/d/1tGpzZaQxoTAcxs_n
 ottrpal::include_slide("https://docs.google.com/presentation/d/1tGpzZaQxoTAcxs_nyyNL2FOqypjEofEnMVpBtZiAw4A/edit#slide=id.g116ca06e27d_0_293")
     ```
 
-1. Clicking on the Billing Account name will allow you to manage the account, including accessing reports, setting alerts, and managing payments and billing.  We will cover account management in greater detail below.
+1. Clicking on the Billing Account name will allow you to manage the account, including accessing reports, setting alerts, and managing payments and billing.
 
     ```{r, echo=FALSE, fig.alt='Screenshot of the Google Cloud Console Billing Page, with the name of the new billing account highlighted.'}
 ottrpal::include_slide("https://docs.google.com/presentation/d/1tGpzZaQxoTAcxs_nyyNL2FOqypjEofEnMVpBtZiAw4A/edit#slide=id.g116ca06e27d_0_437")


### PR DESCRIPTION
a couple of minor edits to make the instructions for creating a google billing account more general

- changed "lab members" to "team members"
- removed a sentence saying that admin would be "covered in greater detail below"