### PR TITLE
Update deprecated GitHub actions

### DIFF
--- a/.github/workflows/anvil-library-build.yml
+++ b/.github/workflows/anvil-library-build.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout files
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           token: ${{ secrets.gh_pat }}
@@ -65,7 +65,7 @@ jobs:
           Rscript --vanilla "scripts/anvil_repo_check.R" --git_pat "$GH_PAT"
 
       - name: Archive AnVIL repos
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: anvil-repo-results
           path: resources/AnVIL_repos.tsv


### PR DESCRIPTION
We're getting some warnings about deprecations.  Candace is working on updating all the OTTR workflows, but we need to handle `anvil-library-build` ourselves.

Here's the OTTR issue with more details: https://github.com/jhudsl/OTTR_Template/issues/604