### PR TITLE
fix example workspace name if none is provided

### DIFF
--- a/08-student_modules.Rmd
+++ b/08-student_modules.Rmd
@@ -25,6 +25,7 @@ These instructions can be customized to a specific workspace by setting certain 
 ```{r, echo = FALSE, results='asis'}
 cow::borrow_chapter(
   doc_path = "child/_child_student_workspace_clone.Rmd",
+  branch = "fix-student-example-workspace",
   repo_name = "jhudsl/AnVIL_Template"
 )
 ```
@@ -43,6 +44,7 @@ AnVIL_module_settings <- list(
 
 cow::borrow_chapter(
   doc_path = "child/_child_student_workspace_clone.Rmd",
+  branch = "fix-student-example-workspace",
   repo_name = "jhudsl/AnVIL_Template"
 )
 ```

--- a/08-student_modules.Rmd
+++ b/08-student_modules.Rmd
@@ -25,7 +25,6 @@ These instructions can be customized to a specific workspace by setting certain 
 ```{r, echo = FALSE, results='asis'}
 cow::borrow_chapter(
   doc_path = "child/_child_student_workspace_clone.Rmd",
-  branch = "fix-student-example-workspace",
   repo_name = "jhudsl/AnVIL_Template"
 )
 ```
@@ -44,7 +43,6 @@ AnVIL_module_settings <- list(
 
 cow::borrow_chapter(
   doc_path = "child/_child_student_workspace_clone.Rmd",
-  branch = "fix-student-example-workspace",
   repo_name = "jhudsl/AnVIL_Template"
 )
 ```

--- a/child/_child_student_workspace_clone.Rmd
+++ b/child/_child_student_workspace_clone.Rmd
@@ -4,8 +4,10 @@ if (!exists("AnVIL_module_settings")) {
 }
 if (is.null(AnVIL_module_settings$workspace_name)) {
   AnVIL_module_settings$workspace_name = "specified by your instructor"
-}
+  AnVIL_module_settings$clone_name =  "ExampleWorkspace_Firstname_Lastname")
+} else {
 AnVIL_module_settings$clone_name = paste0(AnVIL_module_settings$workspace_name, "_Firstname_Lastname")
+}
 if (is.null(AnVIL_module_settings$workspace_link)) {
   AnVIL_module_settings$workspace_link = "ask your instructor"
 }

--- a/child/_child_student_workspace_clone.Rmd
+++ b/child/_child_student_workspace_clone.Rmd
@@ -4,7 +4,7 @@ if (!exists("AnVIL_module_settings")) {
 }
 if (is.null(AnVIL_module_settings$workspace_name)) {
   AnVIL_module_settings$workspace_name = "specified by your instructor"
-  AnVIL_module_settings$clone_name =  "ExampleWorkspace_Firstname_Lastname")
+  AnVIL_module_settings$clone_name =  "ExampleWorkspace_Firstname_Lastname"
 } else {
 AnVIL_module_settings$clone_name = paste0(AnVIL_module_settings$workspace_name, "_Firstname_Lastname")
 }


### PR DESCRIPTION
fix student example Workspace name so that if no Workspace name is provided it uses `ExampleWorkspace_Firstname_Lastname`

previously it was using `specified by your instructor_Firstname_Lastname`