### PR TITLE
remove second css link

### DIFF
--- a/assets/AnVIL_style/big-image_anvil.html
+++ b/assets/AnVIL_style/big-image_anvil.html
@@ -2,7 +2,6 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1.0,maximum-scale=10.0,initial-scale=1.0">
   <!--script src="https://kit.fontawesome.com/6a26f47516.js"></script-->
   <!--<script src="assets/hideOutput.js"></script>-->
-  <link href="assets/AnvIL_style/style.css" rel="stylesheet">
 </head>
         
 

--- a/assets/GDSCN_style/big-image_gdscn.html
+++ b/assets/GDSCN_style/big-image_gdscn.html
@@ -2,7 +2,6 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1.0,maximum-scale=10.0,initial-scale=1.0">
   <!--script src="https://kit.fontawesome.com/6a26f47516.js"></script-->
   <!--<script src="assets/hideOutput.js"></script>-->
-  <link href="assets/GDSCN_style/style.css" rel="stylesheet">
 </head>
 
 


### PR DESCRIPTION
Resolves #113 

In https://github.com/jhudsl/AnVIL_Book_Instructor_Guide/pull/96, the preview wasn't loading the css.  After investigating I noticed that this extra link is incorrect anyway (lowercase `v` in AnVIL).  Just deleting this link fixed the problem; the AnVIL style loaded just fine from the link in `_output.yml`.

I don't know why this was originally here, but since it now seems to be a potential source of problems, and things seem to work just fine without it, I'm going to go ahead and delete it.