### PR TITLE
Make feedback instructions match the new unified form

### DIFF
--- a/.github/automatic-issues/add-feedback-method.md
+++ b/.github/automatic-issues/add-feedback-method.md
@@ -7,4 +7,4 @@ A feedback method (Google Form) has already been provided for AnVIL and GDSCN co
 
 *No further action is needed on your part*. However, if you would like to change the feedback method, you can do so by editing [this line of code](https://github.com/jhudsl/AnVIL_Template/blob/7c501e9804cf88a151832bb0a9bbc1eae9d23fdf/_output.yml#L19) in `_output.yml`.
 
-[See these instructions](https://docs.google.com/document/d/1uhGafEkbtJL3ar3TVHqRFypwTbXjudHa7h2mXu53CkA/edit?usp=sharing) for instructions on how to manually create a feedback link for AnVIL / GDSCN content. 
+[See these instructions](https://docs.google.com/document/d/1uhGafEkbtJL3ar3TVHqRFypwTbXjudHa7h2mXu53CkA/edit?usp=sharing) for how to manually create a feedback link for AnVIL / GDSCN content or events.

--- a/.github/automatic-issues/add-feedback-method.md
+++ b/.github/automatic-issues/add-feedback-method.md
@@ -1,8 +1,10 @@
 
 To help users report issues or areas of improvement for your course, you should provide a clear method of feedback for your users to route their concerns through.
 
-A feedback method (Google Form) has already been provided for AnVIL and GDSCN courses. When users give you feedback they can enter the name of your course. You can make it easier for them by adding the course to form:
+A feedback method (Google Form) has already been provided for AnVIL and GDSCN courses. Github actions automatically populates the Google Form with the `title` field from [`index.Rmd`](https://github.com/jhudsl/AnVIL_Template/blob/main/index.Rmd) using the [AnVIL Feedback Script](https://github.com/jhudsl/AnVIL_Template/blob/main/scripts/AnVIL_Feedback_Script.sh).
 
-- [ ] Add your course name here: https://forms.gle/AK12iVXTjsB7yCUUA.
+- [ ] The `title` field has been filled out in the header yaml of `index.Rmd`.
 
-[See these instructions](https://github.com/jhudsl/OTTR_Template/wiki/Set-up-feedback-method) for more suggestions on how to add a feedback method for this course. 
+*No further action is needed on your part*. However, if you would like to change the feedback method, you can do so by editing [this line of code](https://github.com/jhudsl/AnVIL_Template/blob/7c501e9804cf88a151832bb0a9bbc1eae9d23fdf/_output.yml#L19) in `_output.yml`.
+
+[See these instructions](https://docs.google.com/document/d/1uhGafEkbtJL3ar3TVHqRFypwTbXjudHa7h2mXu53CkA/edit?usp=sharing) for instructions on how to manually create a feedback link for AnVIL / GDSCN content. 


### PR DESCRIPTION
Realized that the automatic issue as is doesn't reflect the new auto-populating, unified Google Form. This should make the process more clear for new repos.

- Users don't have to do anything except fill in the title on index.Rmd
- Users can change the feedback method if they really want
- If users want an additional pre-populated form, they can see the google doc instructions for doing so

@KatherineCox appreciate any feedback on the language here for clarity!