### PR TITLE
Add file for table for AnVIL Book Status 

### DIFF
--- a/13-data_modules.Rmd
+++ b/13-data_modules.Rmd
@@ -10,8 +10,7 @@ Modules aimed importing and managing data on AnVIL.
 ```{r, echo = FALSE, results='asis'}
 cow::borrow_chapter(
   doc_path = "child/_child_data_from_HPC_to_AnVIL.Rmd",
-  repo_name = "jhudsl/AnVIL_Template",
-  branch = "preview-232"
+  repo_name = "jhudsl/AnVIL_Template"
 )
 ```
 ::::

--- a/resources/AnVIL_Template_CollectionStatus_Table.html
+++ b/resources/AnVIL_Template_CollectionStatus_Table.html
@@ -7,11 +7,11 @@
     <th>Number of Open PRs</th>
     <th>Website up?</th>
   </tr>
-  <!--
+  <!-- Comment showing row format
   <tr> new row
     <th><a href="https://github.com/{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}" target="_blank">{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}</a></th>
     <th><a href="https://github.com/{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}" alt="Open Issues"></a></th>
     <th><a href="https://github.com/{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}/branches" target="_blank"> <img src="https://badgen.net/github/branches/{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}" alt="Open PRs"></a></th>
     <th><a href="https://{jhudatascience.org|hutchdatascience.org}/{REPO_NAME}" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
@@ -20,7 +20,7 @@
   <tr>
     <th><a href="https://github.com/jhudsl/AnVIL_Book_Getting_Started" target="_blank">jhudsl/AnVIL_Book_Getting_Started</a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_Book_Getting_Started/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/AnVIL_Book_Getting_Started/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/jhudsl/AnVIL_Book_Getting_Started/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/AnVIL_Book_Getting_Started" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_Getting_Started/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/jhudsl/AnVIL_Book_Getting_Started" alt="Open Issues"></a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_Book_Getting_Started/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/AnVIL_Book_Getting_Started" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_Book_Getting_Started/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/AnVIL_Book_Getting_Started" alt="Open PRs"></a></th>
     <th><a href="https://jhudatascience.org/AnVIL_Book_Getting_Started/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -28,7 +28,7 @@
   <tr>
     <th><a href="https://github.com/fhdsl/AnVIL_Demos" target="_blank">fhdsl/AnVIL_Demos</a></th>
     <th><a href="https://github.com/fhdsl/AnVIL_Demos/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/AnVIL_Demos/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/fhdsl/AnVIL_Demos/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/AnVIL_Demos" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Demos/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/fhdsl/AnVIL_Demos" alt="Open Issues"></a></th>
     <th><a href="https://github.com/fhdsl/AnVIL_Demos/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/AnVIL_Demos" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/fhdsl/AnVIL_Demos/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/AnVIL_Demos" alt="Open PRs"></a></th>
     <th><a href="https://hutchdatascience.org/AnVIL_Demos/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -36,7 +36,7 @@
   <tr>
     <th><a href="https://github.com/fhdsl/AnVIL_Collection" target="_blank">fhdsl/AnVIL_Collection</a></th>
     <th><a href="https://github.com/fhdsl/AnVIL_Collection/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/AnVIL_Collection/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/fhdsl/AnVIL_Collection/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/AnVIL_Collection" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Collection/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/fhdsl/AnVIL_Collection" alt="Open Issues"></a></th>
     <th><a href="https://github.com/fhdsl/AnVIL_Collection/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/AnVIL_Collection" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/fhdsl/AnVIL_Collection/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/AnVIL_Collection" alt="Open PRs"></a></th>
     <th><a href="https://hutchdatascience.org/AnVIL_Collection/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -44,7 +44,7 @@
   <tr>
     <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL" target="_blank">jhudsl/AnVIL_Book_WDL</a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/AnVIL_Book_WDL/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/AnVIL_Book_WDL" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/jhudsl/AnVIL_Book_WDL" alt="Open Issues"></a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/AnVIL_Book_WDL" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/AnVIL_Book_WDL" alt="Open PRs"></a></th>
     <th><a href="https://jhudatascience.org/AnVIL_Book_WDL/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -52,7 +52,7 @@
   <tr>
     <th><a href="https://github.com/fhdsl/AnVIL_SRA_Data" target="_blank">fhdsl/AnVIL_SRA_Data</a></th>
     <th><a href="https://github.com/fhdsl/AnVIL_SRA_Data/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/AnVIL_SRA_Data/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/fhdsl/AnVIL_SRA_Data/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/AnVIL_SRA_Data" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_SRA_Data/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/fhdsl/AnVIL_SRA_Data" alt="Open Issues"></a></th>
     <th><a href="https://github.com/fhdsl/AnVIL_SRA_Data/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/AnVIL_SRA_Data" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/fhdsl/AnVIL_SRA_Data/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/AnVIL_SRA_Data" alt="Open PRs"></a></th>
     <th><a href="https://hutchdatascience.org/AnVIL_SRA_Data/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -60,7 +60,7 @@
   <tr>
     <th><a href="https://github.com/fhdsl/AnVIL_Data_Subsetting" target="_blank">fhdsl/AnVIL_Data_Subsetting</a></th>
     <th><a href="https://github.com/fhdsl/AnVIL_Data_Subsetting/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/AnVIL_Data_Subsetting/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/fhdsl/AnVIL_Data_Subsetting/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/AnVIL_Data_Subsetting" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Data_Subsetting/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/fhdsl/AnVIL_Data_Subsetting" alt="Open Issues"></a></th>
     <th><a href="https://github.com/fhdsl/AnVIL_Data_Subsetting/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/AnVIL_Data_Subsetting" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/fhdsl/AnVIL_Data_Subsetting/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/AnVIL_Data_Subsetting" alt="Open PRs"></a></th>
     <th><a href="https://hutchdatascience.org/AnVIL_Data_Subsetting/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -68,7 +68,7 @@
   <tr>
     <th><a href="https://github.com/fhdsl/Data_on_AnVIL" target="_blank">fhdsl/Data_on_AnVIL</a></th>
     <th><a href="https://github.com/fhdsl/Data_on_AnVIL/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/Data_on_AnVIL/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/fhdsl/Data_on_AnVIL/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/Data_on_AnVIL" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/Data_on_AnVIL/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/fhdsl/Data_on_AnVIL" alt="Open Issues"></a></th>
     <th><a href="https://github.com/fhdsl/Data_on_AnVIL/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/Data_on_AnVIL" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/fhdsl/Data_on_AnVIL/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/Data_on_AnVIL" alt="Open PRs"></a></th>
     <th><a href="https://hutchdatascience.org/Data_on_AnVIL/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -76,7 +76,7 @@
   <tr>
     <th><a href="https://github.com/jhudsl/AnVIL_Book_Champions" target="_blank">jhudsl/AnVIL_Book_Champions</a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_Book_Champions/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/AnVIL_Book_Champions/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/jhudsl/AnVIL_Book_Champions/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/AnVIL_Book_Champions" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_Champions/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/jhudsl/AnVIL_Book_Champions" alt="Open Issues"></a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_Book_Champions/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/AnVIL_Book_Champions" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_Book_Champions/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/AnVIL_Book_Champions" alt="Open PRs"></a></th>
     <th><a href="https://jhudatascience.org/AnVIL_Book_Champions/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -84,7 +84,7 @@
   <tr>
     <th><a href="https://github.com/jhudsl/AnVIL_Book_Instructor_Guide" target="_blank">jhudsl/AnVIL_Book_Instructor_Guide</a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_Book_Instructor_Guide/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/AnVIL_Book_Instructor_Guide/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/jhudsl/AnVIL_Book_Instructor_Guide/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/AnVIL_Book_Instructor_Guide" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_Instructor_Guide/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/jhudsl/AnVIL_Book_Instructor_Guide" alt="Open Issues"></a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_Book_Instructor_Guide/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/AnVIL_Book_Instructor_Guide" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_Book_Instructor_Guide/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/AnVIL_Book_Instructor_Guide" alt="Open PRs"></a></th>
     <th><a href="https://jhudatascience.org/AnVIL_Book_Instructor_Guide/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -92,7 +92,7 @@
   <tr>
     <th><a href="https://github.com/fhdsl/AnVIL_Book_Epigenetics_Intro" target="_blank">fhdsl/AnVIL_Book_Epigenetics_Intro</a></th>
     <th><a href="https://github.com/fhdsl/AnVIL_Book_Epigenetics_Intro/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/AnVIL_Book_Epigenetics_Intro/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/fhdsl/AnVIL_Book_Epigenetics_Intro/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/AnVIL_Book_Epigenetics_Intro" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Book_Epigenetics_Intro/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/fhdsl/AnVIL_Book_Epigenetics_Intro" alt="Open Issues"></a></th>
     <th><a href="https://github.com/fhdsl/AnVIL_Book_Epigenetics_Intro/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/AnVIL_Book_Epigenetics_Intro" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/fhdsl/AnVIL_Book_Epigenetics_Intro/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/AnVIL_Book_Epigenetics_Intro" alt="Open PRs"></a></th>
     <th><a href="https://hutchdatascience.org/AnVIL_Book_Epigenetics_Intro/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -100,7 +100,7 @@
   <tr>
     <th><a href="https://github.com/jhudsl/AnVIL_Phylogenetic-Techniques" target="_blank">jhudsl/AnVIL_Phylogenetic-Techniques</a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_Phylogenetic-Techniques/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/AnVIL_Phylogenetic-Techniques/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/jhudsl/AnVIL_Phylogenetic-Techniques/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/AnVIL_Phylogenetic-Techniques" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Phylogenetic-Techniques/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/jhudsl/AnVIL_Phylogenetic-Techniques" alt="Open Issues"></a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_Phylogenetic-Techniques/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/AnVIL_Phylogenetic-Techniques" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_Phylogenetic-Techniques/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/AnVIL_Phylogenetic-Techniques" alt="Open PRs"></a></th>
     <th><a href="https://jhudatascience.org/AnVIL_Phylogenetic-Techniques/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -108,7 +108,7 @@
   <tr>
     <th><a href="https://github.com/fhdsl/AnVIL_Urban_Genomics_PCA" target="_blank">fhdsl/AnVIL_Urban_Genomics_PCA</a></th>
     <th><a href="https://github.com/fhdsl/AnVIL_Urban_Genomics_PCA/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/AnVIL_Urban_Genomics_PCA/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/fhdsl/AnVIL_Urban_Genomics_PCA/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/AnVIL_Urban_Genomics_PCA" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Urban_Genomics_PCA/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/fhdsl/AnVIL_Urban_Genomics_PCA" alt="Open Issues"></a></th>
     <th><a href="https://github.com/fhdsl/AnVIL_Urban_Genomics_PCA/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/AnVIL_Urban_Genomics_PCA" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/fhdsl/AnVIL_Urban_Genomics_PCA/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/AnVIL_Urban_Genomics_PCA" alt="Open PRs"></a></th>
     <th><a href="https://hutchdatascience.org/AnVIL_Urban_Genomics_PCA/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -116,7 +116,7 @@
   <tr>
     <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Book" target="_blank">fhdsl/GDSCN_BioDIGS_Book</a></th>
     <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Book/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/GDSCN_BioDIGS_Book/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Book/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/GDSCN_BioDIGS_Book" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Book/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/fhdsl/GDSCN_BioDIGS_Book" alt="Open Issues"></a></th>
     <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Book/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/GDSCN_BioDIGS_Book" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Book/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/GDSCN_BioDIGS_Book" alt="Open PRs"></a></th>
     <th><a href="https://hutchdatascience.org/GDSCN_BioDIGS_Book/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -124,7 +124,7 @@
   <tr>
     <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Soil" target="_blank">fhdsl/GDSCN_BioDIGS_Soil</a></th>
     <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Soil/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/GDSCN_BioDIGS_Soil/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Soil/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/GDSCN_BioDIGS_Soil" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Soil/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/fhdsl/GDSCN_BioDIGS_Soil" alt="Open Issues"></a></th>
     <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Soil/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/GDSCN_BioDIGS_Soil" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Soil/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/GDSCN_BioDIGS_Soil" alt="Open PRs"></a></th>
     <th><a href="https://hutchdatascience.org/GDSCN_BioDIGS_Soil/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -132,7 +132,7 @@
   <tr>
     <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_AMR" target="_blank">fhdsl/GDSCN_BioDIGS_AMR</a></th>
     <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_AMR/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/GDSCN_BioDIGS_AMR/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_AMR/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/GDSCN_BioDIGS_AMR" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_AMR/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/fhdsl/GDSCN_BioDIGS_AMR" alt="Open Issues"></a></th>
     <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_AMR/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/GDSCN_BioDIGS_AMR" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_AMR/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/GDSCN_BioDIGS_AMR" alt="Open PRs"></a></th>
     <th><a href="https://hutchdatascience.org/GDSCN_BioDIGS_AMR/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -140,7 +140,7 @@
   <tr>
     <th><a href="https://github.com/fhdsl/GDSCN_SARS_RStudio_on_AnVIL" target="_blank">fhdsl/GDSCN_SARS_RStudio_on_AnVIL</a></th>
     <th><a href="https://github.com/fhdsl/GDSCN_SARS_RStudio_on_AnVIL/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/GDSCN_SARS_RStudio_on_AnVIL/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/fhdsl/GDSCN_SARS_RStudio_on_AnVIL/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/GDSCN_SARS_RStudio_on_AnVIL" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/GDSCN_SARS_RStudio_on_AnVIL/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/fhdsl/GDSCN_SARS_RStudio_on_AnVIL" alt="Open Issues"></a></th>
     <th><a href="https://github.com/fhdsl/GDSCN_SARS_RStudio_on_AnVIL/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/GDSCN_SARS_RStudio_on_AnVIL" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/fhdsl/GDSCN_SARS_RStudio_on_AnVIL/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/GDSCN_SARS_RStudio_on_AnVIL" alt="Open PRs"></a></th>
     <th><a href="https://hutchdatascience.org/GDSCN_SARS_RStudio_on_AnVIL/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -148,7 +148,7 @@
   <tr>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL" target="_blank">jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL</a></th>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL" alt="Open Issues"></a></th>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL" alt="Open PRs"></a></th>
     <th><a href="https://jhudatascience.org/GDSCN_Book_SARS_Galaxy_on_AnVIL/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -156,7 +156,7 @@
   <tr>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression" target="_blank">jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression</a></th>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression" alt="Open Issues"></a></th>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression" alt="Open PRs"></a></th>
     <th><a href="https://jhudatascience.org/GDSCN_Book_Statistics_for_Genomics_Differential_Expression/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -164,7 +164,7 @@
   <tr>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA" target="_blank">jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA</a></th>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA" alt="Open Issues"></a></th>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA" alt="Open PRs"></a></th>
     <th><a href="https://jhudatascience.org/GDSCN_Book_Statistics_for_Genomics_PCA/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -172,7 +172,7 @@
   <tr>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq" target="_blank">jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq</a></th>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq" alt="Open Issues"></a></th>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq" alt="Open PRs"></a></th>
     <th><a href="https://jhudatascience.org/GDSCN_Book_Statistics_for_Genomics_RNA-seq/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -180,7 +180,7 @@
   <tr>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq" target="_blank">jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq</a></th>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq" alt="Open Issues"></a></th>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq" alt="Open PRs"></a></th>
     <th><a href="https://jhudatascience.org/GDSCN_Book_Statistics_for_Genomics_scRNA-seq/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -188,7 +188,7 @@
   <tr>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_swirl" target="_blank">jhudsl/GDSCN_Book_swirl</a></th>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_swirl/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/GDSCN_Book_swirl/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/jhudsl/GDSCN_Book_swirl/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/GDSCN_Book_swirl" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_swirl/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/jhudsl/GDSCN_Book_swirl" alt="Open Issues"></a></th>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_swirl/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/GDSCN_Book_swirl" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/jhudsl/GDSCN_Book_swirl/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/GDSCN_Book_swirl" alt="Open PRs"></a></th>
     <th><a href="https://jhudatascience.org/GDSCN_Book_swirl/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -196,7 +196,7 @@
   <tr>
     <th><a href="https://github.com/jhudsl/AnVIL_Template_Test" target="_blank">jhudsl/AnVIL_Template_Test</a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_Template_Test/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/AnVIL_Template_Test/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/jhudsl/AnVIL_Template_Test/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/AnVIL_Template_Test" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Template_Test/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/jhudsl/AnVIL_Template_Test" alt="Open Issues"></a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_Template_Test/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/AnVIL_Template_Test" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_Template_Test/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/AnVIL_Template_Test" alt="Open PRs"></a></th>
     <th><a href="https://jhudatascience.org/AnVIL_Template_Test/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -205,7 +205,7 @@
   <tr>
     <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL_Quizzes" target="_blank">jhudsl/AnVIL_Book_WDL_Quizzes</a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL_Quizzes/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/AnVIL_Book_WDL_Quizzes/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL_Quizzes/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/AnVIL_Book_WDL_Quizzes" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL_Quizzes/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/jhudsl/AnVIL_Book_WDL_Quizzes" alt="Open Issues"></a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL_Quizzes/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/AnVIL_Book_WDL_Quizzes" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL_Quizzes/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/AnVIL_Book_WDL_Quizzes" alt="Open PRs"></a></th>
     <th><a href="https://jhudatascience.org/AnVIL_Book_WDL_Quizzes/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -214,7 +214,7 @@
   <tr>
     <th><a href="https://github.com/jhudsl/GDSCN_Template_Test" target="_blank">jhudsl/GDSCN_Template_Test</a></th>
     <th><a href="https://github.com/jhudsl/GDSCN_Template_Test/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/GDSCN_Template_Test/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/jhudsl/GDSCN_Template_Test/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/GDSCN_Template_Test" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Template_Test/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/jhudsl/GDSCN_Template_Test" alt="Open Issues"></a></th>
     <th><a href="https://github.com/jhudsl/GDSCN_Template_Test/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/GDSCN_Template_Test" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/jhudsl/GDSCN_Template_Test/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/GDSCN_Template_Test" alt="Open PRs"></a></th>
     <th><a href="https://jhudatascience.org/GDSCN_Template_Test/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
@@ -222,7 +222,7 @@
   <tr>
     <th><a href="https://github.com/jhudsl/AnVIL_CoFests_2024" target="_blank">jhudsl/AnVIL_CoFests_2024</a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_CoFests_2024/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/AnVIL_CoFests_2024/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
-    <th><a href="https://github.com/jhudsl/AnVIL_CoFests_2024/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/AnVIL_CoFests_2024" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_CoFests_2024/issues?q=is%3Aopen" target="_blank"> <img src="https://img.shields.io/github/issues/jhudsl/AnVIL_CoFests_2024" alt="Open Issues"></a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_CoFests_2024/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/AnVIL_CoFests_2024" alt="GitHub Branches"></a></th>
     <th><a href="https://github.com/jhudsl/AnVIL_CoFests_2024/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/AnVIL_CoFests_2024" alt="Open PRs"></a></th>
     <th><a href="https://jhudatascience.org/AnVIL_CoFests_2024/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>

--- a/resources/AnVIL_Template_CollectionStatus_Table.html
+++ b/resources/AnVIL_Template_CollectionStatus_Table.html
@@ -1,0 +1,230 @@
+<table>
+  <tr>
+    <th>Repo name</th>
+    <th>Render/Package Status</th>
+    <th>Number of Open Issues</th>
+    <th>Number of branches</th>
+    <th>Number of Open PRs</th>
+    <th>Website up?</th>
+  </tr>
+  <!--
+  <tr> new row
+    <th><a href="https://github.com/{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}" target="_blank">{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}</a></th>
+    <th><a href="https://github.com/{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}/branches" target="_blank"> <img src="https://badgen.net/github/branches/{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/{REPO_ORG (e.g., jhudsl|fhdsl)}/{REPO_NAME}" alt="Open PRs"></a></th>
+    <th><a href="https://{jhudatascience.org|hutchdatascience.org}/{REPO_NAME}" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"</a></th>
+  </tr> close new row
+  -->
+  <tr>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_Getting_Started" target="_blank">jhudsl/AnVIL_Book_Getting_Started</a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_Getting_Started/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/AnVIL_Book_Getting_Started/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_Getting_Started/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/AnVIL_Book_Getting_Started" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_Getting_Started/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/AnVIL_Book_Getting_Started" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_Getting_Started/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/AnVIL_Book_Getting_Started" alt="Open PRs"></a></th>
+    <th><a href="https://jhudatascience.org/AnVIL_Book_Getting_Started/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/fhdsl/AnVIL_Demos" target="_blank">fhdsl/AnVIL_Demos</a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Demos/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/AnVIL_Demos/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Demos/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/AnVIL_Demos" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Demos/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/AnVIL_Demos" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Demos/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/AnVIL_Demos" alt="Open PRs"></a></th>
+    <th><a href="https://hutchdatascience.org/AnVIL_Demos/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/fhdsl/AnVIL_Collection" target="_blank">fhdsl/AnVIL_Collection</a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Collection/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/AnVIL_Collection/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Collection/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/AnVIL_Collection" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Collection/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/AnVIL_Collection" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Collection/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/AnVIL_Collection" alt="Open PRs"></a></th>
+    <th><a href="https://hutchdatascience.org/AnVIL_Collection/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL" target="_blank">jhudsl/AnVIL_Book_WDL</a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/AnVIL_Book_WDL/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/AnVIL_Book_WDL" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/AnVIL_Book_WDL" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/AnVIL_Book_WDL" alt="Open PRs"></a></th>
+    <th><a href="https://jhudatascience.org/AnVIL_Book_WDL/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/fhdsl/AnVIL_SRA_Data" target="_blank">fhdsl/AnVIL_SRA_Data</a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_SRA_Data/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/AnVIL_SRA_Data/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_SRA_Data/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/AnVIL_SRA_Data" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_SRA_Data/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/AnVIL_SRA_Data" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_SRA_Data/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/AnVIL_SRA_Data" alt="Open PRs"></a></th>
+    <th><a href="https://hutchdatascience.org/AnVIL_SRA_Data/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/fhdsl/AnVIL_Data_Subsetting" target="_blank">fhdsl/AnVIL_Data_Subsetting</a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Data_Subsetting/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/AnVIL_Data_Subsetting/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Data_Subsetting/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/AnVIL_Data_Subsetting" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Data_Subsetting/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/AnVIL_Data_Subsetting" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Data_Subsetting/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/AnVIL_Data_Subsetting" alt="Open PRs"></a></th>
+    <th><a href="https://hutchdatascience.org/AnVIL_Data_Subsetting/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/fhdsl/Data_on_AnVIL" target="_blank">fhdsl/Data_on_AnVIL</a></th>
+    <th><a href="https://github.com/fhdsl/Data_on_AnVIL/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/Data_on_AnVIL/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/fhdsl/Data_on_AnVIL/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/Data_on_AnVIL" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/Data_on_AnVIL/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/Data_on_AnVIL" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/fhdsl/Data_on_AnVIL/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/Data_on_AnVIL" alt="Open PRs"></a></th>
+    <th><a href="https://hutchdatascience.org/Data_on_AnVIL/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_Champions" target="_blank">jhudsl/AnVIL_Book_Champions</a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_Champions/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/AnVIL_Book_Champions/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_Champions/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/AnVIL_Book_Champions" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_Champions/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/AnVIL_Book_Champions" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_Champions/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/AnVIL_Book_Champions" alt="Open PRs"></a></th>
+    <th><a href="https://jhudatascience.org/AnVIL_Book_Champions/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_Instructor_Guide" target="_blank">jhudsl/AnVIL_Book_Instructor_Guide</a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_Instructor_Guide/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/AnVIL_Book_Instructor_Guide/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_Instructor_Guide/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/AnVIL_Book_Instructor_Guide" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_Instructor_Guide/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/AnVIL_Book_Instructor_Guide" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_Instructor_Guide/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/AnVIL_Book_Instructor_Guide" alt="Open PRs"></a></th>
+    <th><a href="https://jhudatascience.org/AnVIL_Book_Instructor_Guide/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/fhdsl/AnVIL_Book_Epigenetics_Intro" target="_blank">fhdsl/AnVIL_Book_Epigenetics_Intro</a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Book_Epigenetics_Intro/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/AnVIL_Book_Epigenetics_Intro/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Book_Epigenetics_Intro/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/AnVIL_Book_Epigenetics_Intro" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Book_Epigenetics_Intro/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/AnVIL_Book_Epigenetics_Intro" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Book_Epigenetics_Intro/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/AnVIL_Book_Epigenetics_Intro" alt="Open PRs"></a></th>
+    <th><a href="https://hutchdatascience.org/AnVIL_Book_Epigenetics_Intro/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/jhudsl/AnVIL_Phylogenetic-Techniques" target="_blank">jhudsl/AnVIL_Phylogenetic-Techniques</a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Phylogenetic-Techniques/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/AnVIL_Phylogenetic-Techniques/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Phylogenetic-Techniques/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/AnVIL_Phylogenetic-Techniques" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Phylogenetic-Techniques/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/AnVIL_Phylogenetic-Techniques" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Phylogenetic-Techniques/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/AnVIL_Phylogenetic-Techniques" alt="Open PRs"></a></th>
+    <th><a href="https://jhudatascience.org/AnVIL_Phylogenetic-Techniques/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/fhdsl/AnVIL_Urban_Genomics_PCA" target="_blank">fhdsl/AnVIL_Urban_Genomics_PCA</a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Urban_Genomics_PCA/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/AnVIL_Urban_Genomics_PCA/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Urban_Genomics_PCA/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/AnVIL_Urban_Genomics_PCA" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Urban_Genomics_PCA/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/AnVIL_Urban_Genomics_PCA" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/fhdsl/AnVIL_Urban_Genomics_PCA/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/AnVIL_Urban_Genomics_PCA" alt="Open PRs"></a></th>
+    <th><a href="https://hutchdatascience.org/AnVIL_Urban_Genomics_PCA/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Book" target="_blank">fhdsl/GDSCN_BioDIGS_Book</a></th>
+    <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Book/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/GDSCN_BioDIGS_Book/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Book/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/GDSCN_BioDIGS_Book" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Book/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/GDSCN_BioDIGS_Book" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Book/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/GDSCN_BioDIGS_Book" alt="Open PRs"></a></th>
+    <th><a href="https://hutchdatascience.org/GDSCN_BioDIGS_Book/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Soil" target="_blank">fhdsl/GDSCN_BioDIGS_Soil</a></th>
+    <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Soil/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/GDSCN_BioDIGS_Soil/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Soil/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/GDSCN_BioDIGS_Soil" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Soil/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/GDSCN_BioDIGS_Soil" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_Soil/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/GDSCN_BioDIGS_Soil" alt="Open PRs"></a></th>
+    <th><a href="https://hutchdatascience.org/GDSCN_BioDIGS_Soil/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_AMR" target="_blank">fhdsl/GDSCN_BioDIGS_AMR</a></th>
+    <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_AMR/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/GDSCN_BioDIGS_AMR/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_AMR/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/GDSCN_BioDIGS_AMR" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_AMR/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/GDSCN_BioDIGS_AMR" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/fhdsl/GDSCN_BioDIGS_AMR/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/GDSCN_BioDIGS_AMR" alt="Open PRs"></a></th>
+    <th><a href="https://hutchdatascience.org/GDSCN_BioDIGS_AMR/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/fhdsl/GDSCN_SARS_RStudio_on_AnVIL" target="_blank">fhdsl/GDSCN_SARS_RStudio_on_AnVIL</a></th>
+    <th><a href="https://github.com/fhdsl/GDSCN_SARS_RStudio_on_AnVIL/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/fhdsl/GDSCN_SARS_RStudio_on_AnVIL/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/fhdsl/GDSCN_SARS_RStudio_on_AnVIL/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/fhdsl/GDSCN_SARS_RStudio_on_AnVIL" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/fhdsl/GDSCN_SARS_RStudio_on_AnVIL/branches" target="_blank"> <img src="https://badgen.net/github/branches/fhdsl/GDSCN_SARS_RStudio_on_AnVIL" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/fhdsl/GDSCN_SARS_RStudio_on_AnVIL/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/fhdsl/GDSCN_SARS_RStudio_on_AnVIL" alt="Open PRs"></a></th>
+    <th><a href="https://hutchdatascience.org/GDSCN_SARS_RStudio_on_AnVIL/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL" target="_blank">jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL</a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/GDSCN_Book_SARS_Galaxy_on_AnVIL" alt="Open PRs"></a></th>
+    <th><a href="https://jhudatascience.org/GDSCN_Book_SARS_Galaxy_on_AnVIL/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression" target="_blank">jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression</a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/GDSCN_Book_Statistics_for_Genomics_Differential_Expression" alt="Open PRs"></a></th>
+    <th><a href="https://jhudatascience.org/GDSCN_Book_Statistics_for_Genomics_Differential_Expression/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA" target="_blank">jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA</a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/GDSCN_Book_Statistics_for_Genomics_PCA" alt="Open PRs"></a></th>
+    <th><a href="https://jhudatascience.org/GDSCN_Book_Statistics_for_Genomics_PCA/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq" target="_blank">jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq</a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/GDSCN_Book_Statistics_for_Genomics_RNA-seq" alt="Open PRs"></a></th>
+    <th><a href="https://jhudatascience.org/GDSCN_Book_Statistics_for_Genomics_RNA-seq/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq" target="_blank">jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq</a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/GDSCN_Book_Statistics_for_Genomics_scRNA-seq" alt="Open PRs"></a></th>
+    <th><a href="https://jhudatascience.org/GDSCN_Book_Statistics_for_Genomics_scRNA-seq/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_swirl" target="_blank">jhudsl/GDSCN_Book_swirl</a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_swirl/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/GDSCN_Book_swirl/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_swirl/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/GDSCN_Book_swirl" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_swirl/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/GDSCN_Book_swirl" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Book_swirl/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/GDSCN_Book_swirl" alt="Open PRs"></a></th>
+    <th><a href="https://jhudatascience.org/GDSCN_Book_swirl/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/jhudsl/AnVIL_Template_Test" target="_blank">jhudsl/AnVIL_Template_Test</a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Template_Test/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/AnVIL_Template_Test/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Template_Test/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/AnVIL_Template_Test" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Template_Test/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/AnVIL_Template_Test" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Template_Test/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/AnVIL_Template_Test" alt="Open PRs"></a></th>
+    <th><a href="https://jhudatascience.org/AnVIL_Template_Test/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <!-- Private Repo not accessible with badgen
+  <tr>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL_Quizzes" target="_blank">jhudsl/AnVIL_Book_WDL_Quizzes</a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL_Quizzes/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/AnVIL_Book_WDL_Quizzes/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL_Quizzes/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/AnVIL_Book_WDL_Quizzes" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL_Quizzes/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/AnVIL_Book_WDL_Quizzes" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_Book_WDL_Quizzes/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/AnVIL_Book_WDL_Quizzes" alt="Open PRs"></a></th>
+    <th><a href="https://jhudatascience.org/AnVIL_Book_WDL_Quizzes/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  -->
+  <tr>
+    <th><a href="https://github.com/jhudsl/GDSCN_Template_Test" target="_blank">jhudsl/GDSCN_Template_Test</a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Template_Test/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/GDSCN_Template_Test/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Template_Test/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/GDSCN_Template_Test" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Template_Test/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/GDSCN_Template_Test" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/jhudsl/GDSCN_Template_Test/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/GDSCN_Template_Test" alt="Open PRs"></a></th>
+    <th><a href="https://jhudatascience.org/GDSCN_Template_Test/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+  <tr>
+    <th><a href="https://github.com/jhudsl/AnVIL_CoFests_2024" target="_blank">jhudsl/AnVIL_CoFests_2024</a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_CoFests_2024/actions/workflows/render-all.yml" target="_blank"> <img src="https://github.com/jhudsl/AnVIL_CoFests_2024/actions/workflows/render-all.yml/badge.svg" alt="Render all output courses"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_CoFests_2024/issues?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-issues/jhudsl/AnVIL_CoFests_2024" alt="Open Issues"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_CoFests_2024/branches" target="_blank"> <img src="https://badgen.net/github/branches/jhudsl/AnVIL_CoFests_2024" alt="GitHub Branches"></a></th>
+    <th><a href="https://github.com/jhudsl/AnVIL_CoFests_2024/pulls?q=is%3Aopen" target="_blank"> <img src="https://badgen.net/github/open-prs/jhudsl/AnVIL_CoFests_2024" alt="Open PRs"></a></th>
+    <th><a href="https://jhudatascience.org/AnVIL_CoFests_2024/" target="_blank"> <img src="https://img.shields.io/website-up-down-green-red/http/shields.io.svg" alt="Website Status"></a></th>
+  </tr>
+</table>


### PR DESCRIPTION
Adding a status table that reports on the status of active AnVIL Collection books. This is based on the example from the ottrproject Discussions: https://github.com/orgs/ottrproject/discussions/8

Also [added this in the "Discussions" of this repo](https://github.com/jhudsl/AnVIL_Template/discussions/240), however, some status badges aren't working though they work locally (displaying github 403):  

Columns are as follows:
1. Name of the repo (no images, text linking to the repo itself)
2. Rendering Status (image reporting on render status "badge.svg" and linking to the render workflow action for that repo)
3. `#` of open issues (image reporting # using badgen and linking to the open issues for that repo)
4. `#` of branches (image reporting # using badgen and linking to the list of branches for that repo)
5. `#` of open PRs (image reporting # using badgen and linking to the open PRs for that repo)
6. Website status (image reporting status using shields.io and linking to the rendered website)

All links use `target="_blank"` so that links are opened in a new tab

[badgen](https://badgen.net/) is primarily used to generate badge/images. Private repos are not accessible with badgen so one chunk is commented out/not included lower down

The first commented out chunk show the general structure of a table row and uses `{}` to show what needs to be filled in to add a row to the table. 