### PR TITLE
leanpub patch

### DIFF
--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -31,6 +31,7 @@ jobs:
       toggle_website: "${{ env.RENDER_WEBSITE }}"
       toggle_coursera: "${{ env.RENDER_COURSERA }}"
       toggle_leanpub: "${{ env.RENDER_LEANPUB }}"
+      make_book_txt: "${{ env.MAKE_BOOK_TXT }}"
       toggle_feedback_link: "${{ env.FEEDBACK_LINK }}"
       toggle_student_guide: "${{ env.RENDER_STUDENT_GUIDE }}"
       rendering_docker_image: "${{ env.RENDERING_DOCKER_IMAGE }}"

--- a/config_automation.yml
+++ b/config_automation.yml
@@ -25,6 +25,10 @@ render-website: rmd
 render-leanpub: no
 render-coursera: no
 
+## Automate the creation of Book.txt file? yes/no
+## This is only relevant if render-leanpub is yes, otherwise it will be ignored
+make-book-txt: yes
+
 ##### Rendering of student guide (if applicable)
 render-student-guide: yes
 


### PR DESCRIPTION
Making two additions (one to `config_automation.yml` and one to `.github/workflows/render-all.yml`) to handle a necessary argument for leanpub rendering.

I recognize that the default in the template for AnVIL is to skip leanpub rendering but I have seen two examples that used it and needed to have these additions specified. They are ignored if leanpub rendering is turned off and only used if leanpub rendering is turned on. 