### PR TITLE
Updates to _child_rstudio_launch.Rmd

### DIFF
--- a/child/_child_rstudio_launch.Rmd
+++ b/child/_child_rstudio_launch.Rmd
@@ -185,6 +185,16 @@ ottrpal::include_slide("https://docs.google.com/presentation/d/1a35Mb8f0M-bQkBcH
     ```{r, echo=FALSE, fig.alt='Screenshot of the RStudio environment interface.'}
 ottrpal::include_slide("https://docs.google.com/presentation/d/1a35Mb8f0M-bQkBcHa1cyQc6YxXoBLtExCz96nv08vkA/edit#slide=id.g14ea2db115d_0_103")
     ```
+
+:::{.dictionary}
+For more information about configuring your RStudio environment, you can check the Terra docs:
+
+- [Starting and customizing your RStudio app](https://support.terra.bio/hc/en-us/articles/360058138632-Starting-and-customizing-your-RStudio-app)
+- [What packages are installed on preconfigured Cloud Environments?](https://support.terra.bio/hc/en-us/articles/360060989111-What-packages-are-installed-on-preconfigured-Cloud-Environments)
+- [Preconfigure a Cloud Environment with a startup script](https://support.terra.bio/hc/en-us/articles/360058193872-Preconfigure-a-Cloud-Environment-with-a-startup-script)
+- [Cloud Environment FAQs](https://support.terra.bio/hc/en-us/articles/360057425291-Cloud-Environment-FAQs)
+:::
+
 ```{r, include = FALSE}
 AnVIL_module_settings <<- NULL
 ```


### PR DESCRIPTION
I just ran through the instructions for launching RStudio and they're still good, the screenshots are still accurate, so I don't think any updates are needed.

The only thing I was considering is to add this list of links to the bottom of the instructions. Thoughts?
- Is this just clutter? Or a useful addition?
- Is this a good set of links?

Todo:
- [ ] point back to `main` before merging